### PR TITLE
Adjust query editor setting names and tooltips

### DIFF
--- a/docs/content/3_queries/assets_query.md
+++ b/docs/content/3_queries/assets_query.md
@@ -59,9 +59,9 @@ Limitations:
 - Only the `=` operator is available
 - Only `AND` is available when you have multiple tag filters
 
-#### Limit
+#### Max values
 
-The maximum amount of returned datapoints per series.
+The maximum amount of measurements values fetched per series.
 
 ### Advanced options
 
@@ -79,8 +79,8 @@ Includes the database name for the measurement linked to the asset property in t
 
 Includes the description for the measurement linked to the asset property in the label (if one is available).
 
-#### Measurement limit
+#### Max Measurements
 
-Limits the amount of measurements queried.
+Limits the amount of measurements fetched.
 
-Beware: measurements with no points in the configured interval also count towards the limit. These measurements are not visible, making it seem like less measurements than configured were queried.
+Beware: measurements with no points in the configured interval also count towards the limit. These measurements are not visible, making it seem like less measurements than configured were fetched.

--- a/docs/content/3_queries/events_query.md
+++ b/docs/content/3_queries/events_query.md
@@ -56,9 +56,9 @@ The events can be filtered by the values of their `simple` properties.
 - Select a comparison operator (=, !=, <, <=, >, =>)
 - If filtering multiple properties select a logical operator (AND, OR)
 
-### Query asset properties
+### Fetch asset properties
 
-If enabled, you can query asset properties on the selected asset(s), like you would do for an [assets query](./assets_query.md#configuring-the-query).
+If enabled, you can fetch asset properties on the selected asset(s), like you would do for an [assets query](./assets_query.md#configuring-the-query).
 
 #### Asset property selection
 
@@ -97,9 +97,9 @@ Limitations:
 - Only the `=` operator is available
 - Only `AND` is available when you have multiple tag filters
 
-##### Limit (only for periodic queries)
+##### Max values (only for periodic properties)
 
-The maximum amount of returned data points per series.
+The maximum amount of values fetched per property.
 
 #### Advanced options
 
@@ -117,8 +117,8 @@ Includes the database name for the the measurement linked to the asset property 
 
 Includes the description for the the measurement linked to the asset property in the label (if one is available).
 
-##### Measurement limit (only for periodic queries)
+##### Max Measurements (only for periodic queries)
 
-Limits the amount of measurements queried.
+Limits the amount of measurements fetched.
 
-Beware: measurements with no points in the configured interval also count towards the limit. These measurements are not visible, making it seem like less measurements than configured were queried.
+Beware: measurements with no points in the configured interval also count towards the limit. These measurements are not visible, making it seem like less measurements than configured were fetched.

--- a/docs/content/3_queries/measurements_query.md
+++ b/docs/content/3_queries/measurements_query.md
@@ -60,9 +60,9 @@ Limitations:
 - Only the `=` operator is available
 - Only `AND` is available when you have multiple tag filters
 
-#### Limit
+#### Max values
 
-The maximum amount of returned data points per series.
+The maximum amount of measurement values fetched per series.
 
 ### Advanced options
 
@@ -80,8 +80,8 @@ Includes the database name for the selected measurement(s) in the label.
 
 Includes the description for the selected measurement(s) in the label (if one is available).
 
-#### Measurement limit
+#### Max Measurements
 
-Limits the amount of measurements queried.
+Limits the amount of measurements fetched.
 
-Beware: measurements with no points in the configured interval also count towards the limit. These measurements are not visible, making it seem like less measurements than configured were queried.
+Beware: measurements with no points in the configured interval also count towards the limit. These measurements are not visible, making it seem like less measurements than configured were fetched.

--- a/src/QueryEditor/EventFilter.tsx
+++ b/src/QueryEditor/EventFilter.tsx
@@ -348,7 +348,12 @@ export const EventFilter = (props: Props): JSX.Element => {
       {!loading && (
         <>
           <InlineFieldRow>
-            <InlineField grow labelWidth={labelWidth} label="Query Type" tooltip="Specify a property type to work with">
+            <InlineField
+              grow
+              labelWidth={labelWidth}
+              label="Query Type"
+              tooltip="Select the property type: simple or periodic"
+            >
               <Select
                 options={Object.entries(PropertyType)
                   .filter(([_, value]) => isSupportedPropertyType(value, props.datasource.historianInfo?.Version ?? ''))
@@ -360,7 +365,12 @@ export const EventFilter = (props: Props): JSX.Element => {
             </InlineField>
           </InlineFieldRow>
           <InlineFieldRow>
-            <InlineField label="Assets" grow labelWidth={labelWidth} tooltip="Specify an asset to work with">
+            <InlineField
+              label="Assets"
+              grow
+              labelWidth={labelWidth}
+              tooltip="Specify an asset to work with, or use a regex to select multiple assets at once (e.g. /Parent\\\\Child.*/)"
+            >
               <Cascader
                 initialValue={props.query.Assets?.length ? props.query.Assets[0] : ''}
                 initialLabel={initialLabel()}
@@ -390,7 +400,12 @@ export const EventFilter = (props: Props): JSX.Element => {
           </InlineFieldRow>
           <InlineFieldRow>
             {props.multiSelectProperties ? (
-              <InlineField label="Properties" grow labelWidth={labelWidth} tooltip="Specify the properties to include">
+              <InlineField
+                label="Properties"
+                grow
+                labelWidth={labelWidth}
+                tooltip="Specify one or more event properties to work with, or leave empty to use all event properties"
+              >
                 <MultiSelect
                   value={props.query.Properties}
                   options={availableProperties(props.query.EventTypes ?? [], props.query.IncludeParentInfo ?? false)}
@@ -413,7 +428,7 @@ export const EventFilter = (props: Props): JSX.Element => {
               label="Statuses"
               grow
               labelWidth={labelWidth}
-              tooltip="Specify one or more status to work with, selecting none will use all statuses"
+              tooltip="Specify one or more event statuses to filter events on the selected statuses, or leave empty to use all event statuses"
             >
               <MultiSelect value={props.query.Statuses} options={availableStatuses()} onChange={onSelectStatuses} />
             </InlineField>
@@ -421,7 +436,7 @@ export const EventFilter = (props: Props): JSX.Element => {
           <InlineFieldRow>
             <InlineField
               label="WHERE"
-              tooltip="Filters events based on property values (regular and parent)"
+              tooltip="Filter events based on property values of the event or its parent (e.g. event property X value > 0)"
               labelWidth={labelWidth}
             >
               <TagsSection

--- a/src/QueryEditor/Events.tsx
+++ b/src/QueryEditor/Events.tsx
@@ -5,7 +5,7 @@ import { getTemplateSrv } from '@grafana/runtime'
 import { defaultQueryOptions, matchedAssets, tagsToQueryTags, useDebounce } from './util'
 import { EventAssetProperties } from './EventAssetProperties'
 import { DataSource } from 'datasource'
-import { Asset, AssetMeasurementQuery, EventQuery, labelWidth, TimeRange } from 'types'
+import { Asset, AssetMeasurementQuery, EventQuery, labelWidth, PropertyType, TimeRange } from 'types'
 import { EventFilter } from './EventFilter'
 import { DateRangePicker } from 'components/util/DateRangePicker'
 
@@ -134,8 +134,10 @@ export const Events = (props: Props): JSX.Element => {
             />
             <InlineFieldRow>
               <InlineField
-                label="Include parent info"
-                tooltip="For simple properties it will add columns for the parent event and for periodic properties it will add labels"
+                label="Include Parent Event"
+                tooltip={`Adds the simple properties of the parent event as ${
+                  props.query.Type === PropertyType.Simple ? 'fields' : 'labels'
+                }`}
                 labelWidth={labelWidth}
               >
                 <InlineSwitch value={props.query.IncludeParentInfo} onChange={onChangeIncludeParentInfo} />
@@ -170,7 +172,7 @@ export const Events = (props: Props): JSX.Element => {
               </InlineField>
             </InlineFieldRow>
           </FieldSet>
-          <FieldSet label="Query asset properties">
+          <FieldSet label="Fetch Asset Properties">
             <InlineFieldRow>
               <InlineField label="Enabled" labelWidth={labelWidth}>
                 <InlineSwitch value={props.query.QueryAssetProperties} onChange={onChangeQueryAssetProperties} />

--- a/src/QueryEditor/Measurements.tsx
+++ b/src/QueryEditor/Measurements.tsx
@@ -164,7 +164,11 @@ export const Measurements = (props: Props): React.JSX.Element => {
       {!loading && (
         <>
           <InlineFieldRow>
-            <InlineField label="Database" labelWidth={labelWidth} tooltip="Specify a time series database to work with">
+            <InlineField
+              label="Database"
+              labelWidth={labelWidth}
+              tooltip="Filter measurements by one or more databases, or leave empty to include all databases"
+            >
               <DatabaseSelect
                 datasource={props.datasource}
                 templateVariables={props.templateVariables}

--- a/src/QueryEditor/QueryOptions.tsx
+++ b/src/QueryEditor/QueryOptions.tsx
@@ -212,7 +212,9 @@ export const QueryOptions = (props: Props): JSX.Element => {
         <InlineField
           label="Aggregation"
           labelWidth={labelWidth}
-          tooltip={`Specify an aggregation${props.aggregationRequired ? '' : ', leave empty to query raw data'}`}
+          tooltip={`Specify an aggregation and an interval to fetch an aggregated measurement value for each interval${
+            props.aggregationRequired ? '' : ', remove both to fetch raw data'
+          }`}
         >
           <VerticalGroup spacing="xs">
             <HorizontalGroup spacing="xs">
@@ -264,7 +266,7 @@ export const QueryOptions = (props: Props): JSX.Element => {
                   />
                 </InlineField>
               )}
-              <InlineField>
+              <InlineField tooltip="Includes the last known value before the selected time range">
                 <Checkbox
                   label="Include last known point"
                   value={props.state.IncludeLastKnownPoint}
@@ -277,7 +279,7 @@ export const QueryOptions = (props: Props): JSX.Element => {
       </InlineFieldRow>
       {!props.hideGroupBy && (
         <InlineFieldRow>
-          <InlineLabel width={labelWidth} tooltip="Add all tags to group by">
+          <InlineLabel width={labelWidth} tooltip="Group values per tag (e.g. status)">
             Group by
           </InlineLabel>
           <GroupBySection
@@ -302,7 +304,11 @@ export const QueryOptions = (props: Props): JSX.Element => {
       )}
       {!props.hideTagFilter && (
         <InlineFieldRow>
-          <InlineField label="Filter tags" labelWidth={labelWidth}>
+          <InlineField
+            label="Filter tags"
+            tooltip="Filter values by one or more tag conditions (e.g. status = Good)"
+            labelWidth={labelWidth}
+          >
             <TagsSection
               tags={props.tags}
               conditions={['AND']}
@@ -315,7 +321,11 @@ export const QueryOptions = (props: Props): JSX.Element => {
       )}
       {isFeatureEnabled(props.historianVersion, '7.1.0') && (
         <InlineFieldRow>
-          <InlineField label="Filter values" labelWidth={labelWidth}>
+          <InlineField
+            label="Filter values"
+            tooltip="Filter values by one or more conditions (e.g. value > 0)"
+            labelWidth={labelWidth}
+          >
             <TagsSection
               tags={props.valueFilters}
               conditions={['AND', 'OR']}
@@ -330,7 +340,11 @@ export const QueryOptions = (props: Props): JSX.Element => {
       )}
       {!props.hideLimit && (
         <InlineFieldRow>
-          <InlineField label="Limit" labelWidth={labelWidth}>
+          <InlineField
+            label="Max values"
+            tooltip="The maximum amount of values to fetch per measurement"
+            labelWidth={labelWidth}
+          >
             <Input placeholder="(optional)" type="number" onBlur={onLimitChange} defaultValue={props.state.Limit} />
           </InlineField>
         </InlineFieldRow>
@@ -340,7 +354,11 @@ export const QueryOptions = (props: Props): JSX.Element => {
           <br />
           <ControlledCollapse label="Advanced options" isOpen={false}>
             <InlineFieldRow>
-              <InlineField label="Changes only" labelWidth={labelWidth}>
+              <InlineField
+                label="Changes only"
+                tooltip="Hide equal consecutive values (keeps the first value) within the selected time range"
+                labelWidth={labelWidth}
+              >
                 <InlineSwitch value={props.state.ChangesOnly} onChange={onChangeChangesOnly} />
               </InlineField>
             </InlineFieldRow>
@@ -372,8 +390,8 @@ export const QueryOptions = (props: Props): JSX.Element => {
             </InlineFieldRow>
             <InlineFieldRow>
               <InlineField
-                label="Measurement limit"
-                tooltip="The maximum amount of measurement series a query can return"
+                label="Max Measurements"
+                tooltip="The maximum amount of measurements to fetch"
                 labelWidth={labelWidth}
               >
                 <Input value={seriesLimit} type="number" min={0} onChange={onChangeSeriesLimit} />


### PR DESCRIPTION
someone: Run datasource in debug to check if renaming settings does not break stuff