### PR TITLE
Allow dashboard variables in measurement regex queries

### DIFF
--- a/docs/content/3_queries/measurements_query.md
+++ b/docs/content/3_queries/measurements_query.md
@@ -28,6 +28,7 @@ There are a couple of ways to select measurements:
 - Use a dashboard variable (can be done in combination with manually searching and selecting measurements)
 
 Or enable `Use regular expression` and enter a regular expression. The amount of measurements selected by the regular expression might be limited by the [measurement limit](#measurement-limit).
+Dashboard variables can also be used here but it's recommended to use the `${varname}` syntax instead of `$varname` to be able to interpolate a variable in the middle of an expression.
 
 ### Aggregation options
 

--- a/src/components/util/MeasurementSelect.tsx
+++ b/src/components/util/MeasurementSelect.tsx
@@ -2,12 +2,12 @@ import React, { ChangeEvent, useState } from 'react'
 import { SelectableValue } from '@grafana/data'
 import {
   AsyncMultiSelect,
+  AutoSizeInput,
   Checkbox,
   HorizontalGroup,
   Icon,
   InlineField,
   InlineFieldRow,
-  Input,
   Tooltip,
   VerticalGroup,
 } from '@grafana/ui'
@@ -148,7 +148,7 @@ export const MeasurementSelect = (props: Props): React.JSX.Element => {
                 show={regexError !== undefined}
                 interactive={false}
               >
-                <Input value={regex} placeholder="[m|M]otor_[0-9]" onChange={onChangeRegex} />
+                <AutoSizeInput value={regex} placeholder="[m|M]otor_[0-9]" onChange={onChangeRegex}  />
               </Tooltip>
             )}
             <Checkbox label="Use regular expression" value={props.query.IsRegex} onChange={onChangeIsRegex} />

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -92,6 +92,9 @@ export class DataSource extends DataSourceWithBackend<Query, HistorianDataSource
             measurementQuery.Measurements = measurementQuery.Measurements?.flatMap((m) =>
               this.multiSelectReplace(m, request.scopedVars)
             )
+            if (measurementQuery.IsRegex && measurementQuery.Regex) {
+              measurementQuery.Regex = this.templateSrv.replace(measurementQuery.Regex, request.scopedVars)
+            }
             measurementQuery.Options = this.templateReplaceQueryOptions(measurementQuery.Options, request.scopedVars)
             measurementQuery.Options.ValueFilters = measurementQuery.Options.ValueFilters?.filter(
               (e) => e.Value !== 'enter a value'


### PR DESCRIPTION
Couldn't find a good way to show the available variables when entering a regex, using a select with custom values was not a good option