### PR TITLE
test: add frontend unit tests for utilities, components, and QueryEditor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,36 @@ jobs:
       - name: Lint
         run: pnpm run lint
       - name: Unit tests
-        run: pnpm run test:ci
+        run: pnpm run test:coverage
+
+      - name: Extract coverage percentage
+        id: coverage
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            PCT=$(jq -r '.total.lines.pct' coverage/coverage-summary.json)
+          else
+            PCT=0
+          fi
+          echo "pct=$PCT" >> $GITHUB_OUTPUT
+
+      - name: Coverage comment
+        if: github.event_name == 'pull_request'
+        uses: MishaKav/jest-coverage-comment@d1a95e365f7f60e1438b5b36198b8c23e9ea4d59
+        with:
+          coverage-summary-path: ./coverage/coverage-summary.json
+
+      - name: Update coverage badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.COVERAGE_GIST_ID != ''
+        uses: Schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: factry-historian-coverage.json
+          label: coverage
+          message: ${{ steps.coverage.outputs.pct }}%
+          valColorRange: ${{ steps.coverage.outputs.pct }}
+          maxColorRange: 100
+          minColorRange: 0
       - name: Build frontend
         run: pnpm run build
 

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,2 +1,6 @@
 // Jest setup provided by Grafana scaffolding
 import './.config/jest-setup'
+
+// Polyfill TextEncoder/TextDecoder for @grafana/ui compatibility with jsdom
+import { TextDecoder, TextEncoder } from 'util'
+Object.assign(global, { TextDecoder, TextEncoder })

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,33 @@
 // generally used by snapshots, but can affect specific tests
 process.env.TZ = 'UTC'
 
+const baseConfig = require('./.config/jest.config')
+
 module.exports = {
-  // Jest configuration provided by Grafana scaffolding
-  ...require('./.config/jest.config'),
+  ...baseConfig,
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.test.{ts,tsx}',
+    '!src/**/__tests__/**',
+  ],
+  coverageReporters: ['text', 'lcov', 'html', 'json-summary'],
+  coverageProvider: 'v8',
+  transform: {
+    '^.+\\.(t|j)sx?$': [
+      '@swc/jest',
+      {
+        sourceMaps: 'inline',
+        jsc: {
+          parser: {
+            syntax: 'typescript',
+            tsx: true,
+            decorators: false,
+            dynamicImport: true,
+          },
+          // Pin to es2022 — the installed @swc/core does not support es2023
+          target: 'es2022',
+        },
+      },
+    ],
+  },
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
+    "test:coverage": "jest --coverage --passWithNoTests --maxWorkers 4",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "npm run lint -- --fix",

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react'
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
+import { QueryEditor } from './QueryEditor'
+import { DataSource } from './datasource'
+import { Query, TabIndex } from './types'
+import { dateTime } from '@grafana/data'
+
+// Mock @grafana/runtime before importing QueryEditor
+jest.mock('@grafana/runtime', () => ({
+  getTemplateSrv: () => ({ getVariables: () => [] }),
+  config: { featureToggles: {} },
+}))
+
+// Mock heavy sub-editors to isolate QueryEditor rendering logic
+jest.mock('QueryEditor/Assets', () => ({
+  Assets: () => <div data-testid="assets-editor">Assets</div>,
+}))
+jest.mock('QueryEditor/Measurements', () => ({
+  Measurements: () => <div data-testid="measurements-editor">Measurements</div>,
+}))
+jest.mock('QueryEditor/Events', () => ({
+  Events: () => <div data-testid="events-editor">Events</div>,
+}))
+jest.mock('QueryEditor/RawQueryEditor', () => ({
+  RawQueryEditor: () => <div data-testid="raw-query-editor">Raw</div>,
+}))
+
+const mockDatasource = {
+  getInfo: jest.fn().mockResolvedValue({}),
+  defaultTab: TabIndex.Measurements,
+  historianInfo: undefined,
+} as unknown as DataSource
+
+function makeQuery(overrides: Partial<Query> = {}): Query {
+  return {
+    refId: 'A',
+    tabIndex: TabIndex.Measurements,
+    seriesLimit: 0,
+    query: {} as any,
+    queryType: 'MeasurementQuery',
+    ...overrides,
+  }
+}
+
+const defaultProps = {
+  datasource: mockDatasource,
+  query: makeQuery(),
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+  range: {
+    from: dateTime('2024-01-01'),
+    to: dateTime('2024-01-02'),
+    raw: { from: 'now-1d', to: 'now' },
+  },
+}
+
+describe('QueryEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the tab buttons', async () => {
+    render(<QueryEditor {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Assets')).toBeInTheDocument()
+      expect(screen.getByText('Measurements')).toBeInTheDocument()
+      expect(screen.getByText('Events')).toBeInTheDocument()
+      expect(screen.getByText('Raw')).toBeInTheDocument()
+    })
+  })
+
+  it('calls datasource.getInfo on mount', async () => {
+    render(<QueryEditor {...defaultProps} />)
+
+    await waitFor(() => {
+      expect(mockDatasource.getInfo).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('renders Measurements editor when queryType is MeasurementQuery', async () => {
+    const query = makeQuery({ queryType: 'MeasurementQuery', tabIndex: TabIndex.Measurements })
+    render(<QueryEditor {...defaultProps} query={query} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('measurements-editor')).toBeInTheDocument()
+    })
+  })
+
+  it('renders Assets editor when queryType is AssetMeasurementQuery', async () => {
+    const query = makeQuery({ queryType: 'AssetMeasurementQuery', tabIndex: TabIndex.Assets })
+    render(<QueryEditor {...defaultProps} query={query} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assets-editor')).toBeInTheDocument()
+    })
+  })
+
+  it('renders Events editor when queryType is EventQuery', async () => {
+    const query = makeQuery({ queryType: 'EventQuery', tabIndex: TabIndex.Events })
+    render(<QueryEditor {...defaultProps} query={query} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('events-editor')).toBeInTheDocument()
+    })
+  })
+
+  it('renders Raw editor when queryType is RawQuery', async () => {
+    const query = makeQuery({ queryType: 'RawQuery', tabIndex: TabIndex.RawQuery })
+    render(<QueryEditor {...defaultProps} query={query} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('raw-query-editor')).toBeInTheDocument()
+    })
+  })
+
+  it('calls onChange when tab is switched', async () => {
+    const onChange = jest.fn()
+    const query = makeQuery({ queryType: 'MeasurementQuery', tabIndex: TabIndex.Measurements })
+    render(<QueryEditor {...defaultProps} query={query} onChange={onChange} />)
+
+    // Wait for mount to finish
+    await waitFor(() => {
+      expect(screen.getByTestId('measurements-editor')).toBeInTheDocument()
+    })
+
+    // Click the "Assets" tab button
+    await act(async () => {
+      fireEvent.click(screen.getByText('Assets'))
+    })
+
+    expect(onChange).toHaveBeenCalled()
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0]
+    expect(lastCall.queryType).toBe('AssetMeasurementQuery')
+    expect(lastCall.tabIndex).toBe(TabIndex.Assets)
+  })
+
+  it('does not show sub-editor content before mount finishes', () => {
+    // Before componentDidMount resolves, mountFinished is false
+    render(<QueryEditor {...defaultProps} />)
+
+    // Sub-editors should NOT be present yet (mountFinished=false)
+    expect(screen.queryByTestId('measurements-editor')).not.toBeInTheDocument()
+  })
+})

--- a/src/QueryEditor/RawQueryEditor.test.tsx
+++ b/src/QueryEditor/RawQueryEditor.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { RawQueryEditor } from './RawQueryEditor'
+import { DataSource } from 'datasource'
+import { RawQuery } from 'types'
+
+jest.mock('@grafana/runtime', () => ({
+  getTemplateSrv: () => ({ getVariables: () => [] }),
+  config: { featureToggles: {} },
+}))
+
+// Mock @grafana/ui — only provide what RawQueryEditor actually uses
+jest.mock('@grafana/ui', () => ({
+  CodeEditor: ({ value, onBlur }: { value: string; onBlur: (v: string) => void }) => (
+    <textarea data-testid="code-editor" defaultValue={value} onBlur={(e) => onBlur(e.target.value)} />
+  ),
+  InlineField: ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div>
+      <label>{label}</label>
+      {children}
+    </div>
+  ),
+  InlineFieldRow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Select: ({ options, onChange }: { options: Array<{ label: string; value: string }>; onChange: (v: any) => void }) => (
+    <select onChange={(e) => onChange({ value: e.target.value })}>
+      {options?.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  ),
+}))
+
+const mockDatabases = [
+  { UUID: 'db-1', Name: 'InfluxDB', Description: 'Main DB', TimeseriesDatabaseType: { Name: 'InfluxDB' } },
+  { UUID: 'db-2', Name: 'PostgreSQL', Description: 'Second DB', TimeseriesDatabaseType: { Name: 'PostgreSQL' } },
+]
+
+const createMockDatasource = (databases = mockDatabases) =>
+  ({
+    getTimeseriesDatabases: jest.fn().mockResolvedValue(databases),
+  }) as unknown as DataSource
+
+const defaultQuery: RawQuery = {
+  TimeseriesDatabase: '',
+  Query: '',
+}
+
+describe('RawQueryEditor', () => {
+  it('renders nothing while loading', () => {
+    const datasource = createMockDatasource()
+    render(<RawQueryEditor datasource={datasource} query={defaultQuery} onChangeRawQuery={jest.fn()} />)
+    // The component renders an empty fragment until loading finishes
+    expect(screen.queryByText('Database')).not.toBeInTheDocument()
+  })
+
+  it('shows database selector after data loads', async () => {
+    const datasource = createMockDatasource()
+    render(<RawQueryEditor datasource={datasource} query={defaultQuery} onChangeRawQuery={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Database')).toBeInTheDocument()
+    })
+  })
+
+  it('fetches databases from the datasource on mount', async () => {
+    const datasource = createMockDatasource()
+    render(<RawQueryEditor datasource={datasource} query={defaultQuery} onChangeRawQuery={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(datasource.getTimeseriesDatabases).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not show CodeEditor when no database is selected', async () => {
+    const datasource = createMockDatasource()
+    render(<RawQueryEditor datasource={datasource} query={defaultQuery} onChangeRawQuery={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Database')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTestId('code-editor')).not.toBeInTheDocument()
+  })
+
+  it('shows CodeEditor when a database is selected', async () => {
+    const datasource = createMockDatasource()
+    const queryWithDb: RawQuery = { TimeseriesDatabase: 'db-1', Query: 'SELECT *' }
+    render(<RawQueryEditor datasource={datasource} query={queryWithDb} onChangeRawQuery={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('code-editor')).toBeInTheDocument()
+    })
+  })
+
+  it('renders the database label after loading', async () => {
+    const datasource = createMockDatasource()
+    render(<RawQueryEditor datasource={datasource} query={defaultQuery} onChangeRawQuery={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Database')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/QueryEditor/util.test.ts
+++ b/src/QueryEditor/util.test.ts
@@ -1,0 +1,323 @@
+import {
+  debouncePromise,
+  getAggregations,
+  getAggregationsForDatatypes,
+  getAggregationsForVersionAndDatatypes,
+  matchedAssets,
+  migrateMeasurementQuery,
+  propertyFilterToQueryTags,
+  selectable,
+  sortByLabel,
+  sortByName,
+  tagsToQueryTags,
+  valueFiltersToQueryTags,
+} from './util'
+import { AggregationName, Asset, MeasurementQuery } from 'types'
+
+describe('selectable', () => {
+  const store = [
+    { label: 'Alpha', value: 'alpha' },
+    { label: 'Beta', value: 'beta' },
+  ]
+
+  it('returns matching item', () => {
+    const result = selectable(store, 'alpha')
+    expect(result).toEqual([{ label: 'Alpha', value: 'alpha' }])
+  })
+
+  it('returns empty array when value not found', () => {
+    expect(selectable(store, 'gamma')).toEqual([])
+  })
+
+  it('returns empty object when value is undefined', () => {
+    expect(selectable(store, undefined)).toEqual({})
+  })
+})
+
+describe('getAggregations', () => {
+  it('returns all AggregationName values', () => {
+    const result = getAggregations()
+    const expectedValues = Object.values(AggregationName)
+    expect(result.map((r) => r.value)).toEqual(expect.arrayContaining(expectedValues))
+    expect(result).toHaveLength(expectedValues.length)
+  })
+
+  it('each entry has label and value', () => {
+    const result = getAggregations()
+    result.forEach((r) => {
+      expect(r.label).toBeDefined()
+      expect(r.value).toBeDefined()
+    })
+  })
+})
+
+describe('getAggregationsForDatatypes', () => {
+  it('returns all aggregations for number datatype', () => {
+    const result = getAggregationsForDatatypes(['number'])
+    const values = result.map((r) => r.value)
+    expect(values).toContain('mean')
+    expect(values).toContain('sum')
+    expect(values).toContain('count')
+  })
+
+  it('returns limited aggregations for string datatype', () => {
+    const result = getAggregationsForDatatypes(['string'])
+    const values = result.map((r) => r.value)
+    expect(values).toContain('count')
+    expect(values).toContain('first')
+    expect(values).toContain('last')
+    expect(values).toContain('mode')
+    expect(values).not.toContain('mean')
+    expect(values).not.toContain('sum')
+  })
+
+  it('returns limited aggregations for boolean datatype', () => {
+    const result = getAggregationsForDatatypes(['boolean'])
+    const values = result.map((r) => r.value)
+    expect(values).toContain('count')
+    expect(values).toContain('min')
+    expect(values).toContain('max')
+    expect(values).not.toContain('mean')
+  })
+
+  it('returns limited aggregations for array datatype', () => {
+    const result = getAggregationsForDatatypes(['[]number'])
+    const values = result.map((r) => r.value)
+    expect(values).toContain('count')
+    expect(values).toContain('first')
+    expect(values).toContain('last')
+    expect(values).not.toContain('mean')
+  })
+
+  it('returns all aggregations when datatypes is empty', () => {
+    const all = getAggregations()
+    const result = getAggregationsForDatatypes([])
+    expect(result).toHaveLength(all.length)
+  })
+})
+
+describe('getAggregationsForVersionAndDatatypes', () => {
+  it('excludes twa for versions before 7.3.0', () => {
+    const result = getAggregationsForVersionAndDatatypes([], '7.2.0')
+    expect(result.map((r) => r.value)).not.toContain('twa')
+  })
+
+  it('includes twa for version 7.3.0', () => {
+    const result = getAggregationsForVersionAndDatatypes([], '7.3.0')
+    expect(result.map((r) => r.value)).toContain('twa')
+  })
+
+  it('includes twa for versions after 7.3.0', () => {
+    const result = getAggregationsForVersionAndDatatypes([], '8.0.0')
+    expect(result.map((r) => r.value)).toContain('twa')
+  })
+})
+
+describe('tagsToQueryTags', () => {
+  it('converts attributes to query tags', () => {
+    const result = tagsToQueryTags({ status: 'Good', region: 'EU' })
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ key: 'status', value: 'Good', condition: 'AND', operator: '=' })
+  })
+
+  it('returns empty array for undefined', () => {
+    expect(tagsToQueryTags(undefined)).toEqual([])
+  })
+
+  it('returns empty array for empty object', () => {
+    expect(tagsToQueryTags({})).toEqual([])
+  })
+})
+
+describe('valueFiltersToQueryTags', () => {
+  it('converts value filters to query tags', () => {
+    const result = valueFiltersToQueryTags([
+      { Value: 42, Operator: '>', Condition: 'AND' },
+      { Value: 100, Operator: '<', Condition: 'OR' },
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ key: 'value', value: '42', operator: '>', condition: 'AND' })
+    expect(result[1]).toMatchObject({ key: 'value', value: '100', operator: '<', condition: 'OR' })
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(valueFiltersToQueryTags([])).toEqual([])
+  })
+})
+
+describe('propertyFilterToQueryTags', () => {
+  it('converts property filters to query tags', () => {
+    const result = propertyFilterToQueryTags([
+      { Property: 'severity', Datatype: 'string', Value: 'High', Operator: '=', Condition: 'AND', Parent: false },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ key: 'severity', value: 'High', operator: '=', condition: 'AND' })
+  })
+
+  it('handles undefined value as empty string', () => {
+    const result = propertyFilterToQueryTags([
+      { Property: 'severity', Datatype: 'string', Value: undefined, Operator: '=', Condition: 'AND', Parent: false },
+    ])
+    expect(result[0].value).toBe('')
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(propertyFilterToQueryTags([])).toEqual([])
+  })
+})
+
+describe('matchedAssets', () => {
+  const assets: Asset[] = [
+    { Name: 'Pump-01', UUID: 'uuid-1', Description: '', Status: 'active', AssetPath: '/factory/Pump-01' },
+    { Name: 'Pump-02', UUID: 'uuid-2', Description: '', Status: 'active', AssetPath: '/factory/Pump-02' },
+    { Name: 'Motor-A', UUID: 'uuid-3', Description: '', Status: 'active', AssetPath: '/factory/Motor-A' },
+  ]
+
+  it('matches by UUID', () => {
+    const result = matchedAssets(['uuid-1'], assets)
+    expect(result).toHaveLength(1)
+    expect(result[0].UUID).toBe('uuid-1')
+  })
+
+  it('matches by regex against AssetPath', () => {
+    const result = matchedAssets(['/Pump.*/'], assets)
+    expect(result).toHaveLength(2)
+  })
+
+  it('matches by regex against Name when AssetPath is absent', () => {
+    const assetsNoPath: Asset[] = [
+      { Name: 'Sensor-1', UUID: 'uuid-4', Description: '', Status: 'active' },
+      { Name: 'Valve-1', UUID: 'uuid-5', Description: '', Status: 'active' },
+    ]
+    const result = matchedAssets(['/Sensor.*/'], assetsNoPath)
+    expect(result).toHaveLength(1)
+    expect(result[0].UUID).toBe('uuid-4')
+  })
+
+  it('returns empty array when selectedAssets is empty', () => {
+    expect(matchedAssets([], assets)).toEqual([])
+  })
+
+  it('returns empty array when no match found', () => {
+    expect(matchedAssets(['uuid-999'], assets)).toEqual([])
+  })
+
+  it('handles invalid regex gracefully (no match)', () => {
+    const result = matchedAssets(['/[invalid/'], assets)
+    expect(result).toEqual([])
+  })
+})
+
+describe('sortByLabel', () => {
+  it('sorts alphabetically ascending', () => {
+    const items = [{ label: 'Zebra' }, { label: 'Apple' }, { label: 'Mango' }]
+    const sorted = [...items].sort(sortByLabel)
+    expect(sorted.map((i) => i.label)).toEqual(['Apple', 'Mango', 'Zebra'])
+  })
+
+  it('is case-insensitive', () => {
+    const items = [{ label: 'b' }, { label: 'A' }]
+    const sorted = [...items].sort(sortByLabel)
+    expect(sorted.map((i) => i.label)).toEqual(['A', 'b'])
+  })
+
+  it('returns 0 when labels are missing', () => {
+    expect(sortByLabel({}, {})).toBe(0)
+  })
+})
+
+describe('sortByName', () => {
+  it('sorts alphabetically ascending', () => {
+    const items = [{ Name: 'Zebra' }, { Name: 'Apple' }, { Name: 'Mango' }]
+    const sorted = [...items].sort(sortByName)
+    expect(sorted.map((i) => i.Name)).toEqual(['Apple', 'Mango', 'Zebra'])
+  })
+})
+
+describe('migrateMeasurementQuery', () => {
+  it('does not mutate a query without regex measurements', () => {
+    const query: MeasurementQuery = {
+      IsRegex: false,
+      Measurements: ['uuid-1', 'uuid-2'],
+      Options: {} as any,
+    }
+    const result = migrateMeasurementQuery(query)
+    expect(result.IsRegex).toBe(false)
+    expect(result.Measurements).toEqual(['uuid-1', 'uuid-2'])
+  })
+
+  it('migrates regex-formatted measurement to Regex field', () => {
+    const query: MeasurementQuery = {
+      IsRegex: false,
+      Measurements: ['/sensor-.*/'],
+      Options: {} as any,
+    }
+    const result = migrateMeasurementQuery(query)
+    expect(result.IsRegex).toBe(true)
+    expect(result.Regex).toBe('sensor-.*')
+    expect(result.Measurements).toEqual([])
+  })
+
+  it('does not mutate the original query', () => {
+    const query: MeasurementQuery = {
+      IsRegex: false,
+      Measurements: ['/sensor-.*/'],
+      Options: {} as any,
+    }
+    migrateMeasurementQuery(query)
+    expect(query.IsRegex).toBe(false)
+    expect(query.Regex).toBeUndefined()
+    expect(query.Measurements).toEqual(['/sensor-.*/'])
+  })
+})
+
+describe('debouncePromise', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('delays function execution by the specified wait time', async () => {
+    const fn = jest.fn().mockResolvedValue('result')
+    const debounced = debouncePromise(fn, 200)
+
+    const promise = debounced('arg')
+    expect(fn).not.toHaveBeenCalled()
+
+    jest.advanceTimersByTime(200)
+    const result = await promise
+    expect(fn).toHaveBeenCalledWith('arg')
+    expect(result).toBe('result')
+  })
+
+  it('only calls the function once for multiple rapid calls', async () => {
+    const fn = jest.fn().mockResolvedValue('result')
+    const debounced = debouncePromise(fn, 200)
+
+    debounced('a')
+    debounced('b')
+    const promise = debounced('c')
+
+    jest.advanceTimersByTime(200)
+    await promise
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith('c')
+  })
+
+  it('all callers during debounce window receive the same resolved value', async () => {
+    const fn = jest.fn().mockResolvedValue('shared')
+    const debounced = debouncePromise(fn, 200)
+
+    const p1 = debounced('x')
+    const p2 = debounced('x')
+    const p3 = debounced('x')
+
+    jest.advanceTimersByTime(200)
+    const results = await Promise.all([p1, p2, p3])
+    expect(results).toEqual(['shared', 'shared', 'shared'])
+  })
+})

--- a/src/QueryEditor/util.ts
+++ b/src/QueryEditor/util.ts
@@ -382,10 +382,10 @@ export function migrateMeasurementQuery(query: MeasurementQuery): MeasurementQue
     ...query,
   }
   if (!query.IsRegex && query.Measurements?.find((e) => e.length >= 2 && e.startsWith('/') && e.endsWith('/'))) {
-    query.IsRegex = true
-    query.Regex = query.Measurements?.find((e) => e.length >= 2 && e.startsWith('/') && e.endsWith('/'))
-    query.Regex = query.Regex?.substring(1, query.Regex.length - 1)
-    query.Measurements = []
+    measurementQuery.IsRegex = true
+    measurementQuery.Regex = query.Measurements?.find((e) => e.length >= 2 && e.startsWith('/') && e.endsWith('/'))
+    measurementQuery.Regex = measurementQuery.Regex?.substring(1, measurementQuery.Regex.length - 1)
+    measurementQuery.Measurements = []
   }
 
   return measurementQuery

--- a/src/components/Cascader/Cascader.test.tsx
+++ b/src/components/Cascader/Cascader.test.tsx
@@ -1,0 +1,169 @@
+import { Cascader, CascaderOption, CascaderProps } from './Cascader'
+import { createTheme } from '@grafana/data'
+
+// Build a minimal props object for instantiating the Cascader class in unit tests.
+// We only need enough to satisfy TypeScript — render tests use the full component below.
+function makeProps(overrides: Partial<CascaderProps> = {}): CascaderProps {
+  return {
+    theme: createTheme(),
+    options: [],
+    onSelect: jest.fn(),
+    ...overrides,
+  } as CascaderProps
+}
+
+describe('Cascader.flattenOptions', () => {
+  it('returns an empty array for empty options', () => {
+    const cascader = new Cascader(makeProps())
+    expect(cascader.flattenOptions([])).toEqual([])
+  })
+
+  it('returns flat leaf options unchanged', () => {
+    const options: CascaderOption[] = [
+      { label: 'Alpha', value: 'alpha' },
+      { label: 'Beta', value: 'beta' },
+    ]
+    const cascader = new Cascader(makeProps({ options }))
+    const result = cascader.flattenOptions(options)
+    expect(result).toHaveLength(2)
+    expect(result[0].label).toBe('Alpha')
+    expect(result[0].value).toEqual(['alpha'])
+  })
+
+  it('includes branch nodes and their leaf children', () => {
+    const options: CascaderOption[] = [
+      {
+        label: 'Parent',
+        value: 'parent',
+        items: [
+          { label: 'Child-1', value: 'child-1' },
+          { label: 'Child-2', value: 'child-2' },
+        ],
+      },
+    ]
+    const cascader = new Cascader(makeProps({ options }))
+    const result = cascader.flattenOptions(options)
+    // branch node + 2 children = 3 entries
+    expect(result).toHaveLength(3)
+    const labels = result.map((r) => r.label)
+    expect(labels).toContain('Parent')
+    expect(labels).toContain('Parent / Child-1')
+    expect(labels).toContain('Parent / Child-2')
+  })
+
+  it('builds label path using default separator (" / ")', () => {
+    const options: CascaderOption[] = [
+      {
+        label: 'A',
+        value: 'a',
+        items: [{ label: 'B', value: 'b', items: [{ label: 'C', value: 'c' }] }],
+      },
+    ]
+    const cascader = new Cascader(makeProps({ options }))
+    const result = cascader.flattenOptions(options)
+    const deepest = result.find((r) => r.singleLabel === 'C')
+    expect(deepest?.label).toBe('A / B / C')
+  })
+
+  it('uses custom separator when provided', () => {
+    const options: CascaderOption[] = [
+      {
+        label: 'A',
+        value: 'a',
+        items: [{ label: 'B', value: 'b' }],
+      },
+    ]
+    const cascader = new Cascader(makeProps({ options, separator: ' > ' }))
+    const result = cascader.flattenOptions(options)
+    const child = result.find((r) => r.singleLabel === 'B')
+    expect(child?.label).toBe('A > B')
+  })
+
+  it('builds correct value paths for nested options', () => {
+    const options: CascaderOption[] = [
+      {
+        label: 'Root',
+        value: 'root',
+        items: [{ label: 'Leaf', value: 'leaf' }],
+      },
+    ]
+    const cascader = new Cascader(makeProps({ options }))
+    const result = cascader.flattenOptions(options)
+    const leaf = result.find((r) => r.singleLabel === 'Leaf')
+    expect(leaf?.value).toEqual(['root', 'leaf'])
+  })
+
+  it('handles deeply nested options', () => {
+    const options: CascaderOption[] = [
+      {
+        label: 'L1',
+        value: 'l1',
+        items: [
+          {
+            label: 'L2',
+            value: 'l2',
+            items: [
+              {
+                label: 'L3',
+                value: 'l3',
+                items: [{ label: 'L4', value: 'l4' }],
+              },
+            ],
+          },
+        ],
+      },
+    ]
+    const cascader = new Cascader(makeProps({ options }))
+    const result = cascader.flattenOptions(options)
+    const deepest = result.find((r) => r.singleLabel === 'L4')
+    expect(deepest?.label).toBe('L1 / L2 / L3 / L4')
+    expect(deepest?.value).toEqual(['l1', 'l2', 'l3', 'l4'])
+  })
+})
+
+describe('Cascader.getSearchableOptions (memoization)', () => {
+  it('returns the same reference for identical input', () => {
+    const options: CascaderOption[] = [{ label: 'A', value: 'a' }]
+    const cascader = new Cascader(makeProps({ options }))
+    const first = cascader.getSearchableOptions(options)
+    const second = cascader.getSearchableOptions(options)
+    expect(first).toBe(second)
+  })
+
+  it('returns a new result when options change', () => {
+    const options1: CascaderOption[] = [{ label: 'A', value: 'a' }]
+    const options2: CascaderOption[] = [{ label: 'B', value: 'b' }]
+    const cascader = new Cascader(makeProps())
+    const first = cascader.getSearchableOptions(options1)
+    const second = cascader.getSearchableOptions(options2)
+    expect(first).not.toBe(second)
+  })
+})
+
+describe('Cascader.setInitialValue', () => {
+  it('returns empty label when initValue is undefined', () => {
+    const cascader = new Cascader(makeProps())
+    const result = cascader.setInitialValue([], undefined)
+    expect(result).toEqual({ rcValue: [], activeLabel: '' })
+  })
+
+  it('finds the matching option and returns its label', () => {
+    const options: CascaderOption[] = [{ label: 'Pump', value: 'pump-uuid' }]
+    const cascader = new Cascader(makeProps({ options }))
+    const searchable = cascader.flattenOptions(options)
+    const result = cascader.setInitialValue(searchable, 'pump-uuid')
+    expect(result.activeLabel).toBe('Pump')
+  })
+
+  it('returns empty when no matching option and allowCustomValue is false', () => {
+    const cascader = new Cascader(makeProps({ allowCustomValue: false }))
+    const result = cascader.setInitialValue([], 'unknown-uuid')
+    expect(result).toEqual({ rcValue: [], activeLabel: '' })
+  })
+
+  it('returns the raw value as label when allowCustomValue is true and no match', () => {
+    const cascader = new Cascader(makeProps({ allowCustomValue: true }))
+    const result = cascader.setInitialValue([], 'custom-value')
+    expect(result).toEqual({ rcValue: [], activeLabel: 'custom-value' })
+  })
+})

--- a/src/util/semver.test.ts
+++ b/src/util/semver.test.ts
@@ -1,0 +1,85 @@
+import { isFeatureEnabled, semverCompare } from './semver'
+
+describe('semverCompare', () => {
+  it('returns 0 for equal versions', () => {
+    expect(semverCompare('1.2.3', '1.2.3')).toBe(0)
+  })
+
+  it('returns positive when a is greater by major', () => {
+    expect(semverCompare('2.0.0', '1.9.9')).toBeGreaterThan(0)
+  })
+
+  it('returns negative when a is less by major', () => {
+    expect(semverCompare('1.0.0', '2.0.0')).toBeLessThan(0)
+  })
+
+  it('returns positive when a is greater by minor', () => {
+    expect(semverCompare('1.3.0', '1.2.9')).toBeGreaterThan(0)
+  })
+
+  it('returns negative when a is less by minor', () => {
+    expect(semverCompare('1.2.0', '1.3.0')).toBeLessThan(0)
+  })
+
+  it('returns positive when a is greater by patch', () => {
+    expect(semverCompare('1.2.4', '1.2.3')).toBeGreaterThan(0)
+  })
+
+  it('returns negative when a is less by patch', () => {
+    expect(semverCompare('1.2.2', '1.2.3')).toBeLessThan(0)
+  })
+
+  it('treats pre-release as less than release', () => {
+    expect(semverCompare('1.0.0-alpha', '1.0.0')).toBeLessThan(0)
+    expect(semverCompare('1.0.0', '1.0.0-alpha')).toBeGreaterThan(0)
+  })
+
+  it('handles v-prefixed versions', () => {
+    expect(semverCompare('v1.2.3', '1.2.3')).toBe(0)
+    expect(semverCompare('v2.0.0', 'v1.0.0')).toBeGreaterThan(0)
+  })
+
+  it('debug version (non-semver) is treated as greater than any version', () => {
+    expect(semverCompare('not-a-version', '9.9.9')).toBeGreaterThan(0)
+  })
+
+  it('two debug versions are equal', () => {
+    expect(semverCompare('debug', 'also-debug')).toBe(0)
+  })
+
+  it('debug vs debug returns 0', () => {
+    expect(semverCompare('not-valid', 'also-not-valid')).toBe(0)
+  })
+})
+
+describe('isFeatureEnabled', () => {
+  it('returns true when version equals target', () => {
+    expect(isFeatureEnabled('7.3.0', '7.3.0')).toBe(true)
+  })
+
+  it('returns true when version is above target', () => {
+    expect(isFeatureEnabled('8.0.0', '7.3.0')).toBe(true)
+  })
+
+  it('returns false when version is below target', () => {
+    expect(isFeatureEnabled('7.2.9', '7.3.0')).toBe(false)
+  })
+
+  it('returns true for debug/non-semver versions (treated as latest)', () => {
+    expect(isFeatureEnabled('debug', '99.0.0')).toBe(true)
+  })
+
+  it('handles v-prefixed version strings', () => {
+    expect(isFeatureEnabled('v7.3.0', '7.3.0')).toBe(true)
+    expect(isFeatureEnabled('v7.2.0', '7.3.0')).toBe(false)
+  })
+
+  it('with includePreReleases=true, strips pre-release before comparing', () => {
+    // v7.3.0-beta should be treated as 7.3.0 when includePreReleases=true
+    expect(isFeatureEnabled('7.3.0-beta', '7.3.0', true)).toBe(true)
+  })
+
+  it('without includePreReleases, pre-release version is less than release', () => {
+    expect(isFeatureEnabled('7.3.0-alpha', '7.3.0')).toBe(false)
+  })
+})

--- a/src/util/util.test.ts
+++ b/src/util/util.test.ts
@@ -1,0 +1,95 @@
+import { isRegex, isUUID, isValidRegex } from './util'
+
+describe('isRegex', () => {
+  it('returns true for a valid regex string', () => {
+    expect(isRegex('/foo/')).toBe(true)
+  })
+
+  it('returns true for a complex regex', () => {
+    expect(isRegex('/^sensor-[0-9]+$/')).toBe(true)
+  })
+
+  it('returns false for a plain string', () => {
+    expect(isRegex('foo')).toBe(false)
+  })
+
+  it('returns false for an empty string', () => {
+    expect(isRegex('')).toBe(false)
+  })
+
+  it('returns false for a single slash', () => {
+    expect(isRegex('/')).toBe(false)
+  })
+
+  it('returns true for two slashes (edge case: empty regex)', () => {
+    expect(isRegex('//')).toBe(true)
+  })
+
+  it('returns false when only starts with slash', () => {
+    expect(isRegex('/foo')).toBe(false)
+  })
+
+  it('returns false when only ends with slash', () => {
+    expect(isRegex('foo/')).toBe(false)
+  })
+})
+
+describe('isValidRegex', () => {
+  it('returns true for a valid regex string', () => {
+    expect(isValidRegex('/^foo.*bar$/')).toBe(true)
+  })
+
+  it('returns true for a simple pattern', () => {
+    expect(isValidRegex('/sensor/')).toBe(true)
+  })
+
+  it('returns false for an invalid regex pattern', () => {
+    expect(isValidRegex('/[/')).toBe(false)
+  })
+
+  it('returns false for an unclosed group', () => {
+    expect(isValidRegex('/(unclosed/')).toBe(false)
+  })
+
+  it('returns false for a plain string (not regex-formatted)', () => {
+    expect(isValidRegex('foo')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isValidRegex('')).toBe(false)
+  })
+
+  it('returns true for empty regex //', () => {
+    expect(isValidRegex('//')).toBe(true)
+  })
+})
+
+describe('isUUID', () => {
+  it('returns true for a valid UUID v4', () => {
+    expect(isUUID('550e8400-e29b-41d4-a716-446655440000')).toBe(true)
+  })
+
+  it('returns true for uppercase UUID', () => {
+    expect(isUUID('550E8400-E29B-41D4-A716-446655440000')).toBe(true)
+  })
+
+  it('returns true for mixed-case UUID', () => {
+    expect(isUUID('550e8400-E29B-41d4-A716-446655440000')).toBe(true)
+  })
+
+  it('returns false for a plain string', () => {
+    expect(isUUID('not-a-uuid')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(isUUID('')).toBe(false)
+  })
+
+  it('returns false for UUID with wrong segment lengths', () => {
+    expect(isUUID('550e8400-e29b-41d4-a716-44665544000')).toBe(false)
+  })
+
+  it('returns false for UUID missing hyphens', () => {
+    expect(isUUID('550e8400e29b41d4a716446655440000')).toBe(false)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./.config/tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "types": ["react", "react-dom"],
+    "types": ["react", "react-dom", "jest", "testing-library__jest-dom"],
     "noUnusedLocals": false
   }
 }


### PR DESCRIPTION
- Add tests for src/util/util.ts (isRegex, isValidRegex, isUUID)
- Add tests for src/util/semver.ts (semverCompare, isFeatureEnabled)
- Add tests for src/QueryEditor/util.ts (selectable, aggregation filters, asset matching, tag converters, debouncePromise, migration helpers)
- Add tests for src/QueryEditor/RawQueryEditor.tsx (loading state, database fetch, CodeEditor visibility)
- Add tests for src/components/Cascader/Cascader.tsx (flattenOptions, getSearchableOptions memoization, setInitialValue)
- Add tests for src/QueryEditor.tsx (tab rendering, sub-editor switching, onChange propagation)
- Fix jest.config.js to pin SWC target to es2022 (installed @swc/core does not support es2023)
- Add TextEncoder/TextDecoder polyfill to jest-setup.js for @grafana/ui compatibility with jsdom