### PR TITLE
feat(datasource): support string measurements in SQL expressions

### DIFF
--- a/pkg/datasource/dataframe.go
+++ b/pkg/datasource/dataframe.go
@@ -17,6 +17,17 @@ import (
 // fieldLabelsFromMeta are the field labels that are extracted from the metadata
 var fieldLabelsFromMeta = []string{"MeasurementUUID", "MeasurementName", "DatabaseUUID", "DatabaseName", "AssetProperty", "AssetPropertyUUID", "AssetUUID", "AssetPath", "AssetName", "Description"}
 
+// valueFieldName is the historian's value column name in returned frames.
+const valueFieldName = "value"
+
+// Field names produced by the SSE long-format converter; finalizeFlatFrames mirrors them
+// so SQL expressions can reference the same columns regardless of the Auto/Table frame format.
+const (
+	sseValueFieldName       = "__value__"
+	sseMetricNameFieldName  = "__metric_name__"
+	sseDisplayNameFieldName = "__display_name__"
+)
+
 // getLabelsFromFrame returns the tag from a frame
 func getLabelsFromFrame(frame *data.Frame) map[string]interface{} {
 	if frame == nil || frame.Meta == nil {
@@ -232,7 +243,7 @@ func setMeasurementFrameNames(frames data.Frames, options schemas.MeasurementQue
 			continue
 		}
 
-		if field, _ := frame.FieldByName("value"); field != nil {
+		if field, _ := frame.FieldByName(valueFieldName); field != nil {
 			if field.Config == nil {
 				field.Config = &data.FieldConfig{}
 			}
@@ -326,7 +337,7 @@ func setAssetFrameNames(frames data.Frames, assets map[uuid.UUID]schemas.Asset, 
 			custom["AssetUUID"] = property.AssetUUID
 			custom["AssetPath"] = assetPath
 			custom["AssetName"] = asstName
-			if field, _ := frame.FieldByName("value"); field != nil {
+			if field, _ := frame.FieldByName(valueFieldName); field != nil {
 				if field.Config == nil {
 					field.Config = &data.FieldConfig{}
 				}
@@ -341,7 +352,7 @@ func setAssetFrameNames(frames data.Frames, assets map[uuid.UUID]schemas.Asset, 
 
 func fillInitialEmptyIntervals(frames data.Frames, query schemas.Query) data.Frames {
 	for _, frame := range frames {
-		valueField, _ := frame.FieldByName("value")
+		valueField, _ := frame.FieldByName(valueFieldName)
 		if valueField == nil {
 			continue
 		}
@@ -389,159 +400,104 @@ func deleteFirstRow(frames data.Frames) data.Frames {
 	return frames
 }
 
-// addMetaData adds metadata from measurements to data frames and sets the appropriate frame type
-// for Grafana's server-side expression (SSE) SQL engine.
-//
-// Frame type selection for SSE compatibility:
-//   - Numeric/bool measurements → FrameTypeTimeSeriesMulti: the SSE engine converts these to a
-//     long-format table internally (time, __value__, __metric_name__, __display_name__, label columns).
-//   - String measurements → FrameTypeUnknown (empty string): the SSE engine treats frames with an
-//     unrecognized type as flat tabular data, making all columns directly available as SQL columns.
-//     This is the only viable path for strings because:
-//     (a) FrameTypeTimeSeriesMulti: the SSE long conversion skips non-numeric fields
-//         (`if !f.Type().Numeric() { continue }`), producing empty SQL results for strings.
-//     (b) FrameTypeTable: explicitly rejected by the SSE input_conversion with
-//         "unsupported data type [table]" — despite being a named type, it is not supported.
-//     (c) FrameTypeTimeSeriesLong: not supported as SSE input.
-//
-// For FrameTypeUnknown frames, the SSE engine requires that ALL field labels are empty.
-// finalizeStringFrames() must therefore run as the very last step (after setFieldLabels and
-// setAssetFrameNames) to clear labels and manually promote them to plain string columns.
+// addMetaData applies the per-frame field config derived from measurement metadata.
+// Frame-type assignment is done separately in applyFrameFormat so it can be driven by
+// the per-query FrameFormat option and the SSE-detection signal.
 func addMetaData(frames data.Frames, useEngineeringSpecs bool) data.Frames {
 	for _, frame := range frames {
 		setFieldConfig(frame, useEngineeringSpecs)
-		if frame.Meta == nil {
-			continue
-		}
-
-		valueField, _ := frame.FieldByName("value")
-		if valueField != nil && isStringField(valueField) {
-			frame.Meta.Type = data.FrameTypeUnknown
-		} else {
-			frame.Meta.Type = data.FrameTypeTimeSeriesMulti
-		}
 	}
 	return frames
 }
 
-func isStringField(field *data.Field) bool {
-	return field.Type() == data.FieldTypeString || field.Type() == data.FieldTypeNullableString
-}
-
-// maybeConvertStringFrames calls finalizeStringFrames only when sqlCompatible is true,
-// leaving frames untouched otherwise so existing dashboards without SQL expressions
-// continue to receive the standard FrameTypeTimeSeriesMulti layout.
-func maybeConvertStringFrames(sqlCompatible bool, frames data.Frames) data.Frames {
-	if !sqlCompatible {
-		return frames
+// applyFrameFormat assigns frame.Meta.Type per the requested FrameFormat. The default is
+// FrameTypeTimeSeriesMulti (panel-friendly; SSE converts numeric frames internally). Table
+// switches to FrameTypeUnknown + a flat column layout — required for SQL expressions on
+// string measurements (SSE's long converter drops non-numeric value fields). We use
+// FrameTypeUnknown rather than FrameTypeTable because SSE rejects FrameTypeTable as input.
+func applyFrameFormat(frames data.Frames, format schemas.FrameFormat) data.Frames {
+	flatten := format == schemas.FrameFormatTable
+	frameType := data.FrameTypeTimeSeriesMulti
+	if flatten {
+		frameType = data.FrameTypeUnknown
 	}
-	return finalizeStringFrames(frames)
+	for _, frame := range frames {
+		if frame.Meta == nil {
+			continue
+		}
+		frame.Meta.Type = frameType
+	}
+	if flatten {
+		finalizeFlatFrames(frames)
+	}
+	return frames
 }
 
-// finalizeStringFrames converts string measurement frames into a column layout that matches
-// the output the SSE engine produces for numeric FrameTypeTimeSeriesMulti frames, so that
-// SQL expressions can reference the same column names regardless of measurement datatype.
+// finalizeFlatFrames rewrites frames typed as FrameTypeUnknown into a flat column layout that
+// SSE accepts as SQL input. Mirrors what SSE produces from numeric TimeSeriesMulti via its long
+// converter so SQL expressions reference the same columns regardless of measurement datatype:
 //
-// Why this is needed:
-//   - addMetaData marks string frames as FrameTypeUnknown (the flat tabular SSE path).
-//   - setFieldLabels then runs and re-adds metadata labels (MeasurementUUID, MeasurementName, …)
-//     to all value fields as field.Labels.
-//   - The SSE flat tabular path requires ALL field labels to be empty. Any field with labels
-//     causes the engine to reject the frame with "missing data type and has labels".
-//   - This function must therefore run last (after setFieldLabels and setAssetFrameNames) to
-//     clear all field labels and manually promote label data to plain string columns.
+//	time | __value__ | __metric_name__ | __display_name__ | <merged labels alphabetically>
 //
-// Output column layout (mirrors numeric long-format for consistency in SQL expressions):
-//
-//	time | __value__ | __metric_name__ | __display_name__ | <metadata cols alphabetically> | <groupby cols>
-//
-// Note on displayNameFromDS: the SSE SQL engine uses this field config property as the SQL
-// column name for flat tabular frames (not the Go field Name). It must be cleared so the
-// engine falls back to the field Name, which we set to "__value__".
-func finalizeStringFrames(frames data.Frames) data.Frames {
+// SSE rejects any field carrying labels for FrameTypeUnknown ("missing data type and has labels"),
+// so all field labels are cleared and the label data is re-emitted as plain string columns.
+// Must run after setFieldLabels / setAssetFrameNames since those write labels and DisplayNameFromDS.
+func finalizeFlatFrames(frames data.Frames) data.Frames {
 	for _, frame := range frames {
 		if frame.Meta == nil || frame.Meta.Type != data.FrameTypeUnknown {
 			continue
 		}
-		valueField, _ := frame.FieldByName("value")
-		if valueField == nil || !isStringField(valueField) {
+		valueField, _ := frame.FieldByName(valueFieldName)
+		if valueField == nil {
 			continue
 		}
 
-		// Collect GroupBy labels (e.g. status) from frame metadata before clearing,
-		// so they can be promoted to plain columns below.
-		groupByLabels := map[string]string{}
-		if meta, ok := frame.Meta.Custom.(map[string]interface{}); ok {
-			if labels, ok := meta["Labels"].(map[string]interface{}); ok {
-				for k, v := range labels {
-					groupByLabels[k] = fmt.Sprintf("%v", v)
-				}
-			}
-			// Remove from metadata so it is not re-read by setFieldLabels on a future call.
-			delete(meta, "Labels")
-		}
+		labels := mergedLabelsFromMeta(frame)
 
-		// Clear ALL field labels. setFieldLabels (which runs before this function) adds
-		// MeasurementUUID, MeasurementName, etc. as field.Labels. The SSE flat tabular path
-		// rejects any frame where a field has non-empty labels.
 		for _, field := range frame.Fields {
 			field.Labels = nil
 		}
 
-		// Clear displayNameFromDS so the SSE engine uses the field Name as the SQL column name,
-		// then rename the field to __value__ to match the numeric long-format column name.
-		// Save the display name first so it can be written into the __display_name__ column.
-		displayName := ""
+		// SSE uses field Name (not DisplayNameFromDS) as the SQL column name for flat frames.
+		var displayName string
 		if valueField.Config != nil {
 			displayName = valueField.Config.DisplayNameFromDS
 			valueField.Config.DisplayNameFromDS = ""
 		}
-		valueField.Name = "__value__"
+		valueField.Name = sseValueFieldName
 
-		// Add __metric_name__ and __display_name__ columns to mirror the numeric long-format
-		// output produced by the SSE engine's convertTimeSeriesMultiToFullLong conversion.
-		metricName := data.NewField("__metric_name__", nil, make([]string, frame.Rows()))
-		displayNameCol := data.NewField("__display_name__", nil, make([]*string, frame.Rows()))
-		for i := 0; i < frame.Rows(); i++ {
-			metricName.Set(i, "value")
-			if displayName != "" {
-				v := displayName
-				displayNameCol.Set(i, &v)
-			}
-		}
-		frame.Fields = append(frame.Fields, metricName, displayNameCol)
+		rows := frame.Rows()
+		frame.Fields = append(frame.Fields,
+			data.NewField(sseMetricNameFieldName, nil, slices.Repeat([]string{valueFieldName}, rows)),
+			data.NewField(sseDisplayNameFieldName, nil, repeatStringPtr(displayName, rows)),
+		)
 
-		// Promote metadata fields (MeasurementUUID, MeasurementName, etc.) to plain string columns.
-		// Sorted alphabetically to match the column order the SSE engine produces when it iterates
-		// over field.Labels for numeric frames (Go map iteration is sorted by the SSE engine).
-		if meta, ok := frame.Meta.Custom.(map[string]interface{}); ok {
-			sortedKeys := slices.Sorted(slices.Values(fieldLabelsFromMeta))
-			for _, key := range sortedKeys {
-				if value, ok := meta[key].(string); ok && value != "" {
-					col := data.NewField(key, nil, make([]string, frame.Rows()))
-					for i := 0; i < frame.Rows(); i++ {
-						col.Set(i, value)
-					}
-					frame.Fields = append(frame.Fields, col)
-				}
+		for _, key := range slices.Sorted(maps.Keys(labels)) {
+			if labels[key] == "" {
+				continue
 			}
-		}
-
-		// Promote group-by labels (e.g. status) to plain string columns, after the metadata
-		// columns to match the column order of numeric long-format frames.
-		for labelKey, labelValue := range groupByLabels {
-			col := data.NewField(labelKey, nil, make([]string, frame.Rows()))
-			for i := 0; i < frame.Rows(); i++ {
-				col.Set(i, labelValue)
-			}
-			frame.Fields = append(frame.Fields, col)
+			frame.Fields = append(frame.Fields, data.NewField(key, nil, slices.Repeat([]string{labels[key]}, rows)))
 		}
 	}
 	return frames
 }
 
+// repeatStringPtr returns n pointers all referencing the same string. Returns all-nil for
+// empty input so SSE's __display_name__ column reads as null when no display name is set.
+func repeatStringPtr(value string, n int) []*string {
+	out := make([]*string, n)
+	if value == "" {
+		return out
+	}
+	v := value
+	for i := range out {
+		out[i] = &v
+	}
+	return out
+}
+
 func setFieldConfig(frame *data.Frame, useEngineeringSpecs bool) {
-	field, _ := frame.FieldByName("value")
+	field, _ := frame.FieldByName(valueFieldName)
 	if field == nil {
 		return
 	}

--- a/pkg/datasource/dataframe.go
+++ b/pkg/datasource/dataframe.go
@@ -390,12 +390,152 @@ func deleteFirstRow(frames data.Frames) data.Frames {
 	return frames
 }
 
-// addMetaData adds metadata from measurements to data frames
+// addMetaData adds metadata from measurements to data frames and sets the appropriate frame type
+// for Grafana's server-side expression (SSE) SQL engine.
+//
+// Frame type selection for SSE compatibility:
+//   - Numeric/bool measurements → FrameTypeTimeSeriesMulti: the SSE engine converts these to a
+//     long-format table internally (time, __value__, __metric_name__, __display_name__, label columns).
+//   - String measurements → FrameTypeUnknown (empty string): the SSE engine treats frames with an
+//     unrecognized type as flat tabular data, making all columns directly available as SQL columns.
+//     This is the only viable path for strings because:
+//     (a) FrameTypeTimeSeriesMulti: the SSE long conversion skips non-numeric fields
+//         (`if !f.Type().Numeric() { continue }`), producing empty SQL results for strings.
+//     (b) FrameTypeTable: explicitly rejected by the SSE input_conversion with
+//         "unsupported data type [table]" — despite being a named type, it is not supported.
+//     (c) FrameTypeTimeSeriesLong: not supported as SSE input.
+//
+// For FrameTypeUnknown frames, the SSE engine requires that ALL field labels are empty.
+// finalizeStringFrames() must therefore run as the very last step (after setFieldLabels and
+// setAssetFrameNames) to clear labels and manually promote them to plain string columns.
 func addMetaData(frames data.Frames, useEngineeringSpecs bool) data.Frames {
 	for _, frame := range frames {
 		setFieldConfig(frame, useEngineeringSpecs)
-		if frame.Meta != nil {
+		if frame.Meta == nil {
+			continue
+		}
+
+		valueField, _ := frame.FieldByName("value")
+		if valueField != nil && isStringField(valueField) {
+			frame.Meta.Type = data.FrameTypeUnknown
+		} else {
 			frame.Meta.Type = data.FrameTypeTimeSeriesMulti
+		}
+	}
+	return frames
+}
+
+func isStringField(field *data.Field) bool {
+	return field.Type() == data.FieldTypeString || field.Type() == data.FieldTypeNullableString
+}
+
+// maybeConvertStringFrames calls finalizeStringFrames only when sqlCompatible is true,
+// leaving frames untouched otherwise so existing dashboards without SQL expressions
+// continue to receive the standard FrameTypeTimeSeriesMulti layout.
+func maybeConvertStringFrames(sqlCompatible bool, frames data.Frames) data.Frames {
+	if !sqlCompatible {
+		return frames
+	}
+	return finalizeStringFrames(frames)
+}
+
+// finalizeStringFrames converts string measurement frames into a column layout that matches
+// the output the SSE engine produces for numeric FrameTypeTimeSeriesMulti frames, so that
+// SQL expressions can reference the same column names regardless of measurement datatype.
+//
+// Why this is needed:
+//   - addMetaData marks string frames as FrameTypeUnknown (the flat tabular SSE path).
+//   - setFieldLabels then runs and re-adds metadata labels (MeasurementUUID, MeasurementName, …)
+//     to all value fields as field.Labels.
+//   - The SSE flat tabular path requires ALL field labels to be empty. Any field with labels
+//     causes the engine to reject the frame with "missing data type and has labels".
+//   - This function must therefore run last (after setFieldLabels and setAssetFrameNames) to
+//     clear all field labels and manually promote label data to plain string columns.
+//
+// Output column layout (mirrors numeric long-format for consistency in SQL expressions):
+//
+//	time | __value__ | __metric_name__ | __display_name__ | <metadata cols alphabetically> | <groupby cols>
+//
+// Note on displayNameFromDS: the SSE SQL engine uses this field config property as the SQL
+// column name for flat tabular frames (not the Go field Name). It must be cleared so the
+// engine falls back to the field Name, which we set to "__value__".
+func finalizeStringFrames(frames data.Frames) data.Frames {
+	for _, frame := range frames {
+		if frame.Meta == nil || frame.Meta.Type != data.FrameTypeUnknown {
+			continue
+		}
+		valueField, _ := frame.FieldByName("value")
+		if valueField == nil || !isStringField(valueField) {
+			continue
+		}
+
+		// Collect GroupBy labels (e.g. status) from frame metadata before clearing,
+		// so they can be promoted to plain columns below.
+		groupByLabels := map[string]string{}
+		if meta, ok := frame.Meta.Custom.(map[string]interface{}); ok {
+			if labels, ok := meta["Labels"].(map[string]interface{}); ok {
+				for k, v := range labels {
+					groupByLabels[k] = fmt.Sprintf("%v", v)
+				}
+			}
+			// Remove from metadata so it is not re-read by setFieldLabels on a future call.
+			delete(meta, "Labels")
+		}
+
+		// Clear ALL field labels. setFieldLabels (which runs before this function) adds
+		// MeasurementUUID, MeasurementName, etc. as field.Labels. The SSE flat tabular path
+		// rejects any frame where a field has non-empty labels.
+		for _, field := range frame.Fields {
+			field.Labels = nil
+		}
+
+		// Clear displayNameFromDS so the SSE engine uses the field Name as the SQL column name,
+		// then rename the field to __value__ to match the numeric long-format column name.
+		// Save the display name first so it can be written into the __display_name__ column.
+		displayName := ""
+		if valueField.Config != nil {
+			displayName = valueField.Config.DisplayNameFromDS
+			valueField.Config.DisplayNameFromDS = ""
+		}
+		valueField.Name = "__value__"
+
+		// Add __metric_name__ and __display_name__ columns to mirror the numeric long-format
+		// output produced by the SSE engine's convertTimeSeriesMultiToFullLong conversion.
+		metricName := data.NewField("__metric_name__", nil, make([]string, frame.Rows()))
+		displayNameCol := data.NewField("__display_name__", nil, make([]*string, frame.Rows()))
+		for i := 0; i < frame.Rows(); i++ {
+			metricName.Set(i, "value")
+			if displayName != "" {
+				v := displayName
+				displayNameCol.Set(i, &v)
+			}
+		}
+		frame.Fields = append(frame.Fields, metricName, displayNameCol)
+
+		// Promote metadata fields (MeasurementUUID, MeasurementName, etc.) to plain string columns.
+		// Sorted alphabetically to match the column order the SSE engine produces when it iterates
+		// over field.Labels for numeric frames (Go map iteration is sorted by the SSE engine).
+		if meta, ok := frame.Meta.Custom.(map[string]interface{}); ok {
+			sortedKeys := slices.Sorted(slices.Values(fieldLabelsFromMeta))
+			for _, key := range sortedKeys {
+				if value, ok := meta[key].(string); ok && value != "" {
+					col := data.NewField(key, nil, make([]string, frame.Rows()))
+					for i := 0; i < frame.Rows(); i++ {
+						col.Set(i, value)
+					}
+					frame.Fields = append(frame.Fields, col)
+				}
+			}
+		}
+
+		// Promote group-by labels (e.g. status) to plain string columns, after the metadata
+		// columns to match the column order of numeric long-format frames.
+		for labelKey, labelValue := range groupByLabels {
+			col := data.NewField(labelKey, nil, make([]string, frame.Rows()))
+			for i := 0; i < frame.Rows(); i++ {
+				col.Set(i, labelValue)
+			}
+			frame.Fields = append(frame.Fields, col)
 		}
 	}
 	return frames

--- a/pkg/datasource/dataframe.go
+++ b/pkg/datasource/dataframe.go
@@ -126,47 +126,46 @@ func getMeasurementFrameName(frame *data.Frame, includeDatabaseName, includeDesc
 	return getMetaValueFromFrame(frame, "MeasurementName") + getFrameSuffix(frame, includeDatabaseName, includeDescription)
 }
 
+// mergedLabelsFromMeta returns the per-frame label set: the optional Custom["Labels"] map
+// (groupby / tag values) merged with the well-known metadata fields listed in fieldLabelsFromMeta.
+// Returns nil when the frame has no metadata map.
+func mergedLabelsFromMeta(frame *data.Frame) map[string]string {
+	if frame == nil || frame.Meta == nil {
+		return nil
+	}
+	meta, ok := frame.Meta.Custom.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	labels := map[string]string{}
+	if metaLabels, ok := meta["Labels"].(map[string]interface{}); ok {
+		for k, v := range metaLabels {
+			labels[k] = fmt.Sprintf("%v", v)
+		}
+	}
+	for _, key := range fieldLabelsFromMeta {
+		if value, ok := meta[key].(string); ok {
+			labels[key] = value
+		}
+	}
+	return labels
+}
+
 // setFieldLabels sets the labels for a given field
 func setFieldLabels(frames data.Frames) {
 	for _, frame := range frames {
-		if frame == nil {
+		labels := mergedLabelsFromMeta(frame)
+		if labels == nil {
 			continue
 		}
-
-		if frame.Meta == nil {
-			continue
-		}
-
-		meta, ok := frame.Meta.Custom.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		metaLabels, ok := meta["Labels"].(map[string]interface{})
-		if !ok {
-			metaLabels = make(map[string]interface{})
-		}
-
-		labels := data.Labels{}
-		for key, value := range metaLabels {
-			labels[key] = fmt.Sprintf("%v", value)
-		}
-
-		for _, key := range fieldLabelsFromMeta {
-			if value, ok := meta[key].(string); ok {
-				labels[key] = value
-			}
-		}
-
 		for _, field := range frame.Fields {
 			if field.Name == "time" {
 				continue
 			}
-
 			if field.Labels == nil {
 				field.Labels = make(map[string]string)
 			}
-
 			maps.Copy(field.Labels, labels)
 		}
 	}

--- a/pkg/datasource/dataframe_test.go
+++ b/pkg/datasource/dataframe_test.go
@@ -1,0 +1,159 @@
+package datasource
+
+import (
+	"testing"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeFrame builds a single-row frame with a value field of the requested type. Custom metadata
+// includes the standard metadata fields plus a Labels map (the groupby labels source).
+func makeFrame(t *testing.T, valueField *data.Field, displayName string) *data.Frame {
+	t.Helper()
+	timeField := data.NewField("time", nil, []time.Time{time.Unix(0, 0)})
+	if valueField.Config == nil {
+		valueField.Config = &data.FieldConfig{}
+	}
+	valueField.Config.DisplayNameFromDS = displayName
+	frame := data.NewFrame("", timeField, valueField)
+	frame.Meta = &data.FrameMeta{
+		Custom: map[string]interface{}{
+			"MeasurementUUID": "uuid-123",
+			"MeasurementName": "temperature",
+			"DatabaseName":    "factory",
+			"Labels": map[string]interface{}{
+				"status": "Good",
+			},
+		},
+	}
+	return frame
+}
+
+func fieldNames(frame *data.Frame) []string {
+	names := make([]string, 0, len(frame.Fields))
+	for _, f := range frame.Fields {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func TestApplyFrameFormat_AutoNumeric(t *testing.T) {
+	t.Parallel()
+	value := data.NewField("value", nil, []float64{42})
+	frame := makeFrame(t, value, "temperature")
+
+	out := applyFrameFormat(data.Frames{frame}, schemas.FrameFormatAuto)
+
+	require.Len(t, out, 1)
+	assert.Equal(t, data.FrameTypeTimeSeriesMulti, out[0].Meta.Type)
+	assert.Equal(t, []string{"time", "value"}, fieldNames(out[0]))
+}
+
+func TestApplyFrameFormat_AutoString(t *testing.T) {
+	t.Parallel()
+	value := data.NewField("value", nil, []string{"running"})
+	frame := makeFrame(t, value, "state")
+
+	out := applyFrameFormat(data.Frames{frame}, schemas.FrameFormatAuto)
+
+	require.Len(t, out, 1)
+	assert.Equal(t, data.FrameTypeTimeSeriesMulti, out[0].Meta.Type,
+		"string default must keep the panel-friendly shape; users opt into Table for SQL expressions")
+	assert.Equal(t, []string{"time", "value"}, fieldNames(out[0]))
+}
+
+func TestApplyFrameFormat_TableNumeric(t *testing.T) {
+	t.Parallel()
+	value := data.NewField("value", nil, []float64{42})
+	frame := makeFrame(t, value, "temperature")
+
+	out := applyFrameFormat(data.Frames{frame}, schemas.FrameFormatTable)
+
+	require.Len(t, out, 1)
+	assert.Equal(t, data.FrameTypeUnknown, out[0].Meta.Type,
+		"Table flattens numeric frames too for consistency")
+	assertFlatLayout(t, out[0], "temperature")
+}
+
+func TestApplyFrameFormat_TableString(t *testing.T) {
+	t.Parallel()
+	value := data.NewField("value", nil, []string{"running"})
+	frame := makeFrame(t, value, "state")
+
+	out := applyFrameFormat(data.Frames{frame}, schemas.FrameFormatTable)
+
+	require.Len(t, out, 1)
+	assert.Equal(t, data.FrameTypeUnknown, out[0].Meta.Type)
+	assertFlatLayout(t, out[0], "state")
+}
+
+// assertFlatLayout verifies that a flattened frame has the expected SSE-friendly columns and
+// that no field carries labels (SSE rejects labeled fields on FrameTypeUnknown frames).
+func assertFlatLayout(t *testing.T, frame *data.Frame, wantDisplayName string) {
+	t.Helper()
+	names := fieldNames(frame)
+	expected := []string{
+		"time", sseValueFieldName, sseMetricNameFieldName, sseDisplayNameFieldName,
+		"DatabaseName", "MeasurementName", "MeasurementUUID", "status",
+	}
+	assert.Equal(t, expected, names)
+
+	for _, f := range frame.Fields {
+		assert.Empty(t, f.Labels, "field %q must have no labels under FrameTypeUnknown", f.Name)
+	}
+
+	valueField, _ := frame.FieldByName(sseValueFieldName)
+	require.NotNil(t, valueField)
+	assert.Empty(t, valueField.Config.DisplayNameFromDS,
+		"DisplayNameFromDS must be cleared so SSE uses the field Name as the SQL column name")
+
+	metricField, _ := frame.FieldByName(sseMetricNameFieldName)
+	require.NotNil(t, metricField)
+	got, _ := metricField.ConcreteAt(0)
+	assert.Equal(t, valueFieldName, got)
+
+	displayField, _ := frame.FieldByName(sseDisplayNameFieldName)
+	require.NotNil(t, displayField)
+	gotDisplay, ok := displayField.ConcreteAt(0)
+	require.True(t, ok)
+	assert.Equal(t, wantDisplayName, gotDisplay)
+
+	statusField, _ := frame.FieldByName("status")
+	require.NotNil(t, statusField)
+	gotStatus, _ := statusField.ConcreteAt(0)
+	assert.Equal(t, "Good", gotStatus)
+}
+
+// TestApplyFrameFormat_PreservesLabelsMap guards against an earlier regression where the
+// flatten step deleted Custom["Labels"] and broke downstream consumers of the metadata.
+func TestApplyFrameFormat_PreservesLabelsMap(t *testing.T) {
+	t.Parallel()
+	value := data.NewField("value", nil, []string{"running"})
+	frame := makeFrame(t, value, "state")
+	custom, ok := frame.Meta.Custom.(map[string]interface{})
+	require.True(t, ok)
+
+	applyFrameFormat(data.Frames{frame}, schemas.FrameFormatTable)
+
+	labels, ok := custom["Labels"].(map[string]interface{})
+	require.True(t, ok, "Labels map must remain in Meta.Custom")
+	assert.Equal(t, "Good", labels["status"])
+}
+
+// TestApplyFrameFormat_EmptyDisplayName covers the nullable-pointer branch in finalizeFlatFrames.
+func TestApplyFrameFormat_EmptyDisplayName(t *testing.T) {
+	t.Parallel()
+	value := data.NewField("value", nil, []string{"running"})
+	frame := makeFrame(t, value, "")
+
+	out := applyFrameFormat(data.Frames{frame}, schemas.FrameFormatTable)
+
+	displayField, _ := out[0].FieldByName(sseDisplayNameFieldName)
+	require.NotNil(t, displayField)
+	_, ok := displayField.ConcreteAt(0)
+	assert.False(t, ok, "display name column should be null when no display name is set")
+}

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -37,18 +37,12 @@ type Query struct {
 
 // QueryData handles incoming backend queries
 func (ds *HistorianDataSource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	// Grafana's SSE (server-side expression) engine sets X-Grafana-From-Expr: true when it
-	// calls the datasource on behalf of a SQL expression. We detect this here so we can
-	// automatically convert string measurement frames to the flat tabular layout that the
-	// SSE SQL engine requires, without needing a flag in the saved query JSON.
-	sqlCompatible := req.Headers["http_X-Grafana-From-Expr"] == "true"
-
 	return concurrent.QueryData(ctx, req, func(ctx context.Context, query concurrent.Query) (res backend.DataResponse) {
-		return ds.queryData(ctx, query.DataQuery, sqlCompatible)
+		return ds.queryData(ctx, query.DataQuery)
 	}, 10)
 }
 
-func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backend.DataQuery, sqlCompatible bool) backend.DataResponse {
+func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backend.DataQuery) backend.DataResponse {
 	response := backend.DataResponse{}
 	query := Query{}
 	if err := json.Unmarshal(backendQuery.JSON, &query); err != nil {
@@ -65,7 +59,7 @@ func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backe
 			}
 		}
 
-		response.Frames, response.Error = ds.handleAssetMeasurementQuery(ctx, assetMeasurementQuery, backendQuery.TimeRange, backendQuery.Interval, query.SeriesLimit, query.HistorianInfo, sqlCompatible)
+		response.Frames, response.Error = ds.handleAssetMeasurementQuery(ctx, assetMeasurementQuery, backendQuery.TimeRange, backendQuery.Interval, query.SeriesLimit, query.HistorianInfo)
 	case QueryTypeQuery:
 		measurementQuery := schemas.MeasurementQuery{}
 		if err := json.Unmarshal(query.Query, &measurementQuery); err != nil {
@@ -82,7 +76,7 @@ func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backe
 		}
 
 		measurementQuery.Measurements = measurements
-		response.Frames, response.Error = ds.handleMeasurementQuery(ctx, measurementQuery, backendQuery.TimeRange, backendQuery.Interval, sqlCompatible)
+		response.Frames, response.Error = ds.handleMeasurementQuery(ctx, measurementQuery, backendQuery.TimeRange, backendQuery.Interval)
 	case QueryTypeRaw:
 		rawQuery := schemas.RawQuery{}
 		if err := json.Unmarshal(query.Query, &rawQuery); err != nil {
@@ -149,7 +143,7 @@ func findDisplayNameFromDS(frame *data.Frame) string {
 	return ""
 }
 
-func (ds *HistorianDataSource) handleAssetMeasurementQuery(ctx context.Context, assetMeasurementQuery schemas.AssetMeasurementQuery, timeRange backend.TimeRange, interval time.Duration, seriesLimit int, historianInfo *schemas.HistorianInfo, sqlCompatible bool) (data.Frames, error) {
+func (ds *HistorianDataSource) handleAssetMeasurementQuery(ctx context.Context, assetMeasurementQuery schemas.AssetMeasurementQuery, timeRange backend.TimeRange, interval time.Duration, seriesLimit int, historianInfo *schemas.HistorianInfo) (data.Frames, error) {
 	assets, err := ds.API.GetFilteredAssets(ctx, assetMeasurementQuery.Assets, historianInfo)
 	if err != nil {
 		return nil, err
@@ -222,7 +216,7 @@ assetLoop:
 	if measurementQuery.Options.MetadataAsLabels {
 		setFieldLabels(frames)
 	}
-	return maybeConvertStringFrames(sqlCompatible, sortByStatus(frames)), nil
+	return applyFrameFormat(sortByStatus(frames), measurementQuery.Options.FrameFormat), nil
 }
 
 func (ds *HistorianDataSource) getMeasurements(ctx context.Context, measurementQuery schemas.MeasurementQuery, seriesLimit int) ([]string, error) {
@@ -276,7 +270,7 @@ func (ds *HistorianDataSource) getMeasurements(ctx context.Context, measurementQ
 	return parsedMeasurements, nil
 }
 
-func (ds *HistorianDataSource) handleMeasurementQuery(ctx context.Context, measurementQuery schemas.MeasurementQuery, timeRange backend.TimeRange, interval time.Duration, sqlCompatible bool) (data.Frames, error) {
+func (ds *HistorianDataSource) handleMeasurementQuery(ctx context.Context, measurementQuery schemas.MeasurementQuery, timeRange backend.TimeRange, interval time.Duration) (data.Frames, error) {
 	frames, err := ds.handleQuery(ctx, historianQuery(measurementQuery, timeRange, interval), measurementQuery.Options)
 	if err != nil {
 		return nil, err
@@ -286,7 +280,7 @@ func (ds *HistorianDataSource) handleMeasurementQuery(ctx context.Context, measu
 	if measurementQuery.Options.MetadataAsLabels {
 		setFieldLabels(frames)
 	}
-	return maybeConvertStringFrames(sqlCompatible, sortByStatus(frames)), nil
+	return applyFrameFormat(sortByStatus(frames), measurementQuery.Options.FrameFormat), nil
 }
 
 func (ds *HistorianDataSource) handleQuery(ctx context.Context, query schemas.Query, options schemas.MeasurementQueryOptions) (data.Frames, error) {
@@ -347,7 +341,7 @@ func (ds *HistorianDataSource) handleQuery(ctx context.Context, query schemas.Qu
 	}
 	if options.ChangesOnly {
 		for _, frame := range result {
-			valueField, _ := frame.FieldByName("value")
+			valueField, _ := frame.FieldByName(valueFieldName)
 			if valueField == nil {
 				continue
 			}

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -37,12 +37,18 @@ type Query struct {
 
 // QueryData handles incoming backend queries
 func (ds *HistorianDataSource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	// Grafana's SSE (server-side expression) engine sets X-Grafana-From-Expr: true when it
+	// calls the datasource on behalf of a SQL expression. We detect this here so we can
+	// automatically convert string measurement frames to the flat tabular layout that the
+	// SSE SQL engine requires, without needing a flag in the saved query JSON.
+	sqlCompatible := req.Headers["http_X-Grafana-From-Expr"] == "true"
+
 	return concurrent.QueryData(ctx, req, func(ctx context.Context, query concurrent.Query) (res backend.DataResponse) {
-		return ds.queryData(ctx, query.DataQuery)
+		return ds.queryData(ctx, query.DataQuery, sqlCompatible)
 	}, 10)
 }
 
-func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backend.DataQuery) backend.DataResponse {
+func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backend.DataQuery, sqlCompatible bool) backend.DataResponse {
 	response := backend.DataResponse{}
 	query := Query{}
 	if err := json.Unmarshal(backendQuery.JSON, &query); err != nil {
@@ -59,7 +65,7 @@ func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backe
 			}
 		}
 
-		response.Frames, response.Error = ds.handleAssetMeasurementQuery(ctx, assetMeasurementQuery, backendQuery.TimeRange, backendQuery.Interval, query.SeriesLimit, query.HistorianInfo)
+		response.Frames, response.Error = ds.handleAssetMeasurementQuery(ctx, assetMeasurementQuery, backendQuery.TimeRange, backendQuery.Interval, query.SeriesLimit, query.HistorianInfo, sqlCompatible)
 	case QueryTypeQuery:
 		measurementQuery := schemas.MeasurementQuery{}
 		if err := json.Unmarshal(query.Query, &measurementQuery); err != nil {
@@ -76,7 +82,7 @@ func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backe
 		}
 
 		measurementQuery.Measurements = measurements
-		response.Frames, response.Error = ds.handleMeasurementQuery(ctx, measurementQuery, backendQuery.TimeRange, backendQuery.Interval)
+		response.Frames, response.Error = ds.handleMeasurementQuery(ctx, measurementQuery, backendQuery.TimeRange, backendQuery.Interval, sqlCompatible)
 	case QueryTypeRaw:
 		rawQuery := schemas.RawQuery{}
 		if err := json.Unmarshal(query.Query, &rawQuery); err != nil {
@@ -143,7 +149,7 @@ func findDisplayNameFromDS(frame *data.Frame) string {
 	return ""
 }
 
-func (ds *HistorianDataSource) handleAssetMeasurementQuery(ctx context.Context, assetMeasurementQuery schemas.AssetMeasurementQuery, timeRange backend.TimeRange, interval time.Duration, seriesLimit int, historianInfo *schemas.HistorianInfo) (data.Frames, error) {
+func (ds *HistorianDataSource) handleAssetMeasurementQuery(ctx context.Context, assetMeasurementQuery schemas.AssetMeasurementQuery, timeRange backend.TimeRange, interval time.Duration, seriesLimit int, historianInfo *schemas.HistorianInfo, sqlCompatible bool) (data.Frames, error) {
 	assets, err := ds.API.GetFilteredAssets(ctx, assetMeasurementQuery.Assets, historianInfo)
 	if err != nil {
 		return nil, err
@@ -216,7 +222,7 @@ assetLoop:
 	if measurementQuery.Options.MetadataAsLabels {
 		setFieldLabels(frames)
 	}
-	return sortByStatus(frames), nil
+	return maybeConvertStringFrames(sqlCompatible, sortByStatus(frames)), nil
 }
 
 func (ds *HistorianDataSource) getMeasurements(ctx context.Context, measurementQuery schemas.MeasurementQuery, seriesLimit int) ([]string, error) {
@@ -270,7 +276,7 @@ func (ds *HistorianDataSource) getMeasurements(ctx context.Context, measurementQ
 	return parsedMeasurements, nil
 }
 
-func (ds *HistorianDataSource) handleMeasurementQuery(ctx context.Context, measurementQuery schemas.MeasurementQuery, timeRange backend.TimeRange, interval time.Duration) (data.Frames, error) {
+func (ds *HistorianDataSource) handleMeasurementQuery(ctx context.Context, measurementQuery schemas.MeasurementQuery, timeRange backend.TimeRange, interval time.Duration, sqlCompatible bool) (data.Frames, error) {
 	frames, err := ds.handleQuery(ctx, historianQuery(measurementQuery, timeRange, interval), measurementQuery.Options)
 	if err != nil {
 		return nil, err
@@ -280,7 +286,7 @@ func (ds *HistorianDataSource) handleMeasurementQuery(ctx context.Context, measu
 	if measurementQuery.Options.MetadataAsLabels {
 		setFieldLabels(frames)
 	}
-	return sortByStatus(frames), nil
+	return maybeConvertStringFrames(sqlCompatible, sortByStatus(frames)), nil
 }
 
 func (ds *HistorianDataSource) handleQuery(ctx context.Context, query schemas.Query, options schemas.MeasurementQueryOptions) (data.Frames, error) {

--- a/pkg/schemas/queries.go
+++ b/pkg/schemas/queries.go
@@ -2,6 +2,15 @@ package schemas
 
 import "time"
 
+// FrameFormat controls the shape of frames returned to Grafana.
+type FrameFormat string
+
+// FrameFormat values. Empty string is the default (time series) so existing saved queries keep working.
+const (
+	FrameFormatAuto  FrameFormat = ""
+	FrameFormatTable FrameFormat = "table"
+)
+
 // MeasurementQueryOptions are measurement query options
 type MeasurementQueryOptions struct {
 	Tags                   map[string]string
@@ -19,6 +28,7 @@ type MeasurementQueryOptions struct {
 	ValueFilters           []ValueFilter
 	Datatypes              []string
 	Desc                   bool
+	FrameFormat            FrameFormat
 }
 
 // ValueFilter is used to filter the values returned by the historian

--- a/src/QueryEditor/QueryOptions.tsx
+++ b/src/QueryEditor/QueryOptions.tsx
@@ -23,6 +23,7 @@ import {
   Aggregation,
   Attributes,
   fieldWidth,
+  FrameFormat,
   labelWidth,
   MeasurementDatatype,
   MeasurementQueryOptions,
@@ -56,6 +57,11 @@ export interface Props {
 const datatypeOptions: Array<SelectableValue<string>> = Object.entries(MeasurementDatatype).map(([_, value]) => {
   return { label: value, value: value }
 })
+
+const frameFormatOptions: Array<ComboboxOption<FrameFormat>> = [
+  { label: 'Time series', value: FrameFormat.Auto, description: 'Default — time series shape for panel rendering' },
+  { label: 'Table', value: FrameFormat.Table, description: 'Flat tabular shape compatible with SQL expressions and the table panel; required for SQL expressions on string measurements' },
+]
 
 export const QueryOptions = (props: Props): JSX.Element => {
   const [periods, setPeriods] = useState(getPeriods())
@@ -219,6 +225,10 @@ export const QueryOptions = (props: Props): JSX.Element => {
     setOrdering(value)
 
     props.onChange({ ...props.state, Desc: value === 'descending' })
+  }
+
+  const onChangeFrameFormat = (option: ComboboxOption<FrameFormat> | null): void => {
+    props.onChange({ ...props.state, FrameFormat: option?.value ?? FrameFormat.Auto })
   }
 
   return (
@@ -450,6 +460,20 @@ export const QueryOptions = (props: Props): JSX.Element => {
                 labelWidth={labelWidth}
               >
                 <Input value={seriesLimit} onChange={onChangeSeriesLimit} />
+              </InlineField>
+            </InlineFieldRow>
+            <InlineFieldRow>
+              <InlineField
+                label="Format as"
+                labelWidth={labelWidth}
+                tooltip="Default is time series for panel rendering. Pick Table for a flat tabular shape compatible with SQL expressions and the table panel — required for SQL expressions on string measurements."
+              >
+                <Combobox
+                  value={props.state.FrameFormat ?? FrameFormat.Auto}
+                  options={frameFormatOptions}
+                  onChange={onChangeFrameFormat}
+                  width={fieldWidth}
+                />
               </InlineField>
             </InlineFieldRow>
           </ControlledCollapse>

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,11 @@ export interface Aggregation {
   Fill?: string
 }
 
+export enum FrameFormat {
+  Auto = '',
+  Table = 'table',
+}
+
 export interface MeasurementQueryOptions {
   Tags?: Attributes
   GroupBy?: string[]
@@ -102,6 +107,7 @@ export interface MeasurementQueryOptions {
   ChangesOnly?: boolean
   Datatypes?: string[]
   Desc?: boolean
+  FrameFormat?: FrameFormat
 }
 
 export interface ValueFilter {


### PR DESCRIPTION
## Summary

Adds a per-query **Format as** option (Time series / Table) so users can opt into a flat tabular frame layout that is compatible with Grafana's server-side SQL expressions. This is required for string measurements: SSE's long-format converter drops non-numeric value fields, so without flattening, SQL expressions over string measurements return empty results.

- `Time series` (default) keeps the existing `FrameTypeTimeSeriesMulti` shape — no behavior change for existing dashboards.
- `Table` switches to `FrameTypeUnknown` + a flat column layout (`time | __value__ | __metric_name__ | __display_name__ | <metadata cols>`) that mirrors what SSE produces from numeric `TimeSeriesMulti` via its long converter, so SQL expressions reference the same columns regardless of measurement datatype.

The earlier implicit `X-Grafana-From-Expr` header detection has been replaced with this explicit user choice. `FrameTypeUnknown` is used rather than `FrameTypeTable` because SSE rejects `FrameTypeTable` as input.

[PBI 34764: String measurements with sql expressions](https://dev.azure.com/factry/Historian/_workitems/edit/34764)

## Commits

- `refactor(datasource)`: extract `mergedLabelsFromMeta` helper from `setFieldLabels` (pure refactor, used by the new flatten step).
- `feat(datasource)`: add `FrameFormat` option, `applyFrameFormat`, `finalizeFlatFrames`; remove the `X-Grafana-From-Expr` header detection.
- `test(datasource)`: unit tests for `applyFrameFormat` covering numeric/string × time-series/table, label preservation, and the empty-display-name branch.

## Test plan

- [ ] Unit tests pass: `go test ./pkg/datasource/...`
- [ ] Existing dashboard with a string measurement on a state-timeline panel renders identically with the default Format (Time series).
- [ ] Same dashboard with Format = Table renders the flat column layout in a table panel.
- [ ] Create a SQL expression `SELECT * FROM A` over a string measurement with Format = Table — returns columns `time, __value__, __metric_name__, __display_name__, MeasurementName, …`.
- [ ] Same SQL expression with Format = Time series returns no rows for the string column (documented limitation).
- [ ] Numeric measurement works in both Format modes (panel and SQL expression).
- [ ] String measurement linked to ≥2 asset properties with Format = Table — every cloned frame has the full column set (validates Arrow round-trip).