### PR TITLE
fix(query): preserve commas in asset property names

### DIFF
--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,0 +1,103 @@
+import { DataSource } from './datasource'
+import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data'
+import { TemplateSrv } from '@grafana/runtime'
+import { HistorianDataSourceOptions, TabIndex } from './types'
+
+const TEMPLATE_VARIABLE_PATTERN =
+  /\$\{([_a-zA-Z][_a-zA-Z0-9]*)(?::[a-zA-Z0-9_]+)?\}|\$([_a-zA-Z][_a-zA-Z0-9]*)|\[\[([_a-zA-Z][_a-zA-Z0-9]*)(?::[a-zA-Z0-9_]+)?\]\]/
+const TEMPLATE_VARIABLE_GLOBAL_RE = new RegExp(TEMPLATE_VARIABLE_PATTERN, 'g')
+const TEMPLATE_VARIABLE_TEST_RE = new RegExp(TEMPLATE_VARIABLE_PATTERN)
+
+function makeTemplateSrv(values: Record<string, string | string[]>): TemplateSrv {
+  const replace = (
+    value?: string,
+    _scopedVars?: ScopedVars,
+    formatOrFormatter?: string | ((v: string | string[]) => string)
+  ): string => {
+    if (value === undefined) {
+      return ''
+    }
+    return value.replace(TEMPLATE_VARIABLE_GLOBAL_RE, (match, p1, p2, p3) => {
+      const name = p1 ?? p2 ?? p3
+      if (!(name in values)) {
+        return match
+      }
+      const resolved = values[name]
+      if (typeof formatOrFormatter === 'function') {
+        return formatOrFormatter(resolved)
+      }
+      if (formatOrFormatter === 'csv') {
+        return Array.isArray(resolved) ? resolved.join(',') : resolved
+      }
+      return Array.isArray(resolved) ? resolved.join(',') : resolved
+    })
+  }
+
+  return {
+    replace,
+    getVariables: () => [],
+    containsTemplate: (target?: string) => target !== undefined && TEMPLATE_VARIABLE_TEST_RE.test(target),
+    updateTimeRange: () => {},
+  } as unknown as TemplateSrv
+}
+
+function makeDataSource(templateSrv: TemplateSrv): DataSource {
+  const instanceSettings = {
+    id: 1,
+    uid: 'test',
+    type: 'historian',
+    name: 'historian',
+    jsonData: { defaultTab: TabIndex.Measurements } as HistorianDataSourceOptions,
+    meta: { jsonData: {} },
+    readOnly: false,
+    access: 'proxy',
+  } as unknown as DataSourceInstanceSettings<HistorianDataSourceOptions>
+  return new DataSource(instanceSettings, templateSrv)
+}
+
+describe('DataSource.multiSelectReplace', () => {
+  it('preserves a literal comma in an asset property name', () => {
+    const ds = makeDataSource(makeTemplateSrv({}))
+    expect(ds.multiSelectReplace('me:me,me')).toEqual(['me:me,me'])
+  })
+
+  it('preserves a comma inside a resolved variable value', () => {
+    const ds = makeDataSource(makeTemplateSrv({ single: 'foo,bar' }))
+    expect(ds.multiSelectReplace('$single')).toEqual(['foo,bar'])
+  })
+
+  it('expands a multi-value $var into multiple entries', () => {
+    const ds = makeDataSource(makeTemplateSrv({ multi: ['a', 'b', 'c'] }))
+    expect(ds.multiSelectReplace('$multi')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('expands a multi-value [[var]] into multiple entries', () => {
+    const ds = makeDataSource(makeTemplateSrv({ multi: ['a', 'b', 'c'] }))
+    expect(ds.multiSelectReplace('[[multi]]')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns [""] for undefined input', () => {
+    const ds = makeDataSource(makeTemplateSrv({}))
+    expect(ds.multiSelectReplace(undefined)).toEqual([''])
+  })
+})
+
+describe('DataSource.containsTemplate', () => {
+  const ds = makeDataSource(makeTemplateSrv({}))
+
+  it('detects $var syntax', () => {
+    expect(ds.containsTemplate('$foo')).toBe(true)
+  })
+
+  it('detects ${var} syntax', () => {
+    expect(ds.containsTemplate('${foo}')).toBe(true)
+  })
+
+  it('detects [[var]] syntax', () => {
+    expect(ds.containsTemplate('[[foo]]')).toBe(true)
+  })
+
+  it('returns false for plain strings', () => {
+    expect(ds.containsTemplate('me:me,me')).toBe(false)
+  })
+})

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -247,7 +247,18 @@ export class DataSource extends DataSourceWithBackend<Query, HistorianDataSource
 
   // https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/
   multiSelectReplace(value: string | undefined, scopedVars?: ScopedVars): string[] {
-    return this.templateSrv.replace(value, scopedVars, 'csv').split(',')
+    if (value === undefined) {
+      return ['']
+    }
+    if (!this.containsTemplate(value)) {
+      return [value]
+    }
+    // Use ASCII Unit Separator (U+001F) so commas inside resolved values are preserved.
+    const SEP = '\x1F'
+    const replaced = this.templateSrv.replace(value, scopedVars, (v: string | string[]) =>
+      Array.isArray(v) ? v.join(SEP) : v
+    )
+    return replaced.split(SEP)
   }
 
   replace(value: string | undefined, scopedVars?: ScopedVars): string {
@@ -299,7 +310,10 @@ export class DataSource extends DataSourceWithBackend<Query, HistorianDataSource
   containsTemplate(value: string): boolean {
     // Using our own custom function to check for template variables since the templateSrv.containsTemplate() function
     // does not seem to work with scenes in anything but the latest version of Grafana.
-    return typeof value === 'string' && /\$\{?[_a-zA-Z][_a-zA-Z0-9]*(?::[a-zA-Z0-9_]+)?}?/.test(value)
+    return (
+      typeof value === 'string' &&
+      /\$\{?[_a-zA-Z][_a-zA-Z0-9]*(?::[a-zA-Z0-9_]+)?}?|\[\[[_a-zA-Z][_a-zA-Z0-9]*(?::[a-zA-Z0-9_]+)?\]\]/.test(value)
+    )
   }
 
   async getInfo(): Promise<void> {


### PR DESCRIPTION
## Summary

Asset property names containing a comma (e.g. `me:me,me`) were being split on the comma in `multiSelectReplace`, so the backend received `AssetProperties: ["me:me", "me"]` instead of `["me:me,me"]` and the query never returned data.

The fix in `src/datasource.ts`:
- Skip the CSV split entirely when the input has no template variable — literal values are returned as a single-element array.
- When the input does have a template variable, use a custom formatter with ASCII Unit Separator (``) instead of `,`, so commas inside resolved variable values are preserved too.

## Azure DevOps work item

[Bug 35026: Asset property names with special characters can not be fetched with Factry datasource](https://dev.azure.com/factry/Historian/_workitems/edit/35026)

## Testing instructions

1. Create an asset hierarchy `Bug-Test > Child > me:me,me` (any measurement, e.g. `CALC_CONST_NUMBER`).
2. In Grafana, build an `AssetMeasurementQuery` selecting that property.
3. In DevTools → Network, inspect the request payload to `/api/ds/query`. `query.AssetProperties` should be `["me:me,me"]` (single entry), not `["me:me", "me"]`.
4. Panel renders data instead of hanging.
5. Regression check: a multi-value dashboard variable used in the AssetProperties field still expands into multiple entries.