### PR TITLE
fix: change default event annotation query to be ascending instead of…

### DIFF
--- a/src/AnnotationsQueryEditor/AnnotationsQueryEditor.tsx
+++ b/src/AnnotationsQueryEditor/AnnotationsQueryEditor.tsx
@@ -38,7 +38,7 @@ export class AnnotationsQueryEditor extends Component<Props> {
         OverrideAssets: [],
         OverrideTimeRange: false,
         TimeRange: { from: '', to: '' },
-        Ascending: false,
+        Ascending: true,
       })
     }
   }


### PR DESCRIPTION
… descending, which handles events without stop time better