### PR TITLE
fix(events): include parent event assets when resolving parent asset name and path

### DIFF
--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -54,18 +54,37 @@ func (e *HTTPError) Error() string {
 func (api *API) GetFilteredAssets(ctx context.Context, assetStrings []string, historianInfo *schemas.HistorianInfo) (map[uuid.UUID]schemas.Asset, error) {
 	assetUUIDSet := map[uuid.UUID]schemas.Asset{}
 	if util.CheckMinimumVersion(historianInfo, "6.4.0", false) {
+		uuids := make([]string, 0, len(assetStrings))
+		paths := make([]string, 0, len(assetStrings))
 		for _, assetString := range assetStrings {
-			searchKey := "Path"
 			if _, err := uuid.Parse(assetString); err == nil {
-				searchKey = "Keyword"
+				uuids = append(uuids, assetString)
+			} else {
+				paths = append(paths, assetString)
 			}
+		}
+
+		if len(uuids) > 0 {
 			assetQuery := url.Values{}
-			assetQuery.Add(searchKey, assetString)
+			for i, u := range uuids {
+				assetQuery.Add(fmt.Sprintf("UUIDs[%d]", i), u)
+			}
 			assets, err := api.GetAssets(ctx, assetQuery.Encode())
 			if err != nil {
 				return nil, err
 			}
+			for _, asset := range assets {
+				assetUUIDSet[asset.UUID] = asset
+			}
+		}
 
+		for _, path := range paths {
+			assetQuery := url.Values{}
+			assetQuery.Add("Path", path)
+			assets, err := api.GetAssets(ctx, assetQuery.Encode())
+			if err != nil {
+				return nil, err
+			}
 			for _, asset := range assets {
 				assetUUIDSet[asset.UUID] = asset
 			}

--- a/pkg/datasource/event_query_handler.go
+++ b/pkg/datasource/event_query_handler.go
@@ -69,10 +69,31 @@ func (ds *HistorianDataSource) handleEventQuery(ctx context.Context, eventQuery 
 
 	// get all unique event types from the events
 	eventTypeUUIDs := map[uuid.UUID]struct{}{}
+	missingParentAssetUUIDs := map[uuid.UUID]struct{}{}
 	for i := range events {
 		eventTypeUUIDs[events[i].EventTypeUUID] = struct{}{}
 		if eventQuery.IncludeParentInfo && events[i].Parent != nil {
 			eventTypeUUIDs[events[i].Parent.EventTypeUUID] = struct{}{}
+			parentAssetUUID := events[i].Parent.AssetUUID
+			if _, ok := assets[parentAssetUUID]; !ok {
+				missingParentAssetUUIDs[parentAssetUUID] = struct{}{}
+			}
+		}
+	}
+
+	// Parent events often live on assets that are not part of the user's selected
+	// asset filter (e.g. user picks leaf assets, parent event lives on the parent
+	// asset). Fetch those assets so the data-frame builders can populate
+	// Parent_Asset and Parent_AssetPath instead of leaving them empty.
+	parentAssets := map[uuid.UUID]schemas.Asset{}
+	if len(missingParentAssetUUIDs) > 0 {
+		missingAssetStrings := make([]string, 0, len(missingParentAssetUUIDs))
+		for parentAssetUUID := range missingParentAssetUUIDs {
+			missingAssetStrings = append(missingAssetStrings, parentAssetUUID.String())
+		}
+		parentAssets, err = ds.API.GetFilteredAssets(ctx, missingAssetStrings, historianInfo)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -155,16 +176,17 @@ func (ds *HistorianDataSource) handleEventQuery(ctx context.Context, eventQuery 
 		eventTypePropertiesByEventType[eventTypeProperty.EventTypeUUID] = append(eventTypePropertiesByEventType[eventTypeProperty.EventTypeUUID], eventTypeProperty)
 	}
 
-	assetUUIDs := slices.AppendSeq(make([]schemas.Asset, 0, len(assets)), maps.Values(assets))
+	assetsForFrames := slices.AppendSeq(make([]schemas.Asset, 0, len(assets)+len(parentAssets)), maps.Values(assets))
+	assetsForFrames = slices.AppendSeq(assetsForFrames, maps.Values(parentAssets))
 
 	switch eventQuery.Type {
 	case string(schemas.EventTypePropertyTypeSimple):
 		assetPropertyFieldTypes := getAssetPropertyFieldTypes(eventAssetPropertyFrames, multipleAssetsSelected)
-		return EventQueryResultToDataFrame(eventQuery.IncludeParentInfo, multipleAssetsSelected, assetUUIDs, events, allEventTypes, eventTypeProperties, selectedPropertiesSet, assetPropertyFieldTypes, eventAssetPropertyFrames)
+		return EventQueryResultToDataFrame(eventQuery.IncludeParentInfo, multipleAssetsSelected, assetsForFrames, events, allEventTypes, eventTypeProperties, selectedPropertiesSet, assetPropertyFieldTypes, eventAssetPropertyFrames)
 	case string(schemas.EventTypePropertyTypePeriodic):
-		return EventQueryResultToTrendDataFrame(eventQuery.IncludeParentInfo, assetUUIDs, events, util.ByUUID(allEventTypes), eventTypePropertiesByEventType, selectedPropertiesSet, eventAssetPropertyFrames, false)
+		return EventQueryResultToTrendDataFrame(eventQuery.IncludeParentInfo, assetsForFrames, events, util.ByUUID(allEventTypes), eventTypePropertiesByEventType, selectedPropertiesSet, eventAssetPropertyFrames, false)
 	case string(schemas.EventTypePropertyTypePeriodicWithDimension):
-		return EventQueryResultToTrendDataFrame(eventQuery.IncludeParentInfo, assetUUIDs, events, util.ByUUID(allEventTypes), eventTypePropertiesByEventType, selectedPropertiesSet, eventAssetPropertyFrames, true)
+		return EventQueryResultToTrendDataFrame(eventQuery.IncludeParentInfo, assetsForFrames, events, util.ByUUID(allEventTypes), eventTypePropertiesByEventType, selectedPropertiesSet, eventAssetPropertyFrames, true)
 	default:
 		return nil, fmt.Errorf("unsupported event query type %s", eventQuery.Type)
 	}

--- a/pkg/datasource/events_test.go
+++ b/pkg/datasource/events_test.go
@@ -3,8 +3,10 @@ package datasource
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -175,7 +177,14 @@ func newFakeHistorianServer(t *testing.T, fixture fakeHistorianData) *httptest.S
 	mux.HandleFunc("/api/assets", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		var matched []schemas.Asset
+		uuids := indexedValues(q, "UUIDs")
 		switch {
+		case len(uuids) > 0:
+			for _, u := range uuids {
+				if asset, ok := fixture.assetsByUUID[u]; ok {
+					matched = append(matched, asset)
+				}
+			}
 		case q.Get("Path") != "":
 			if asset, ok := fixture.assetsByPath[q.Get("Path")]; ok {
 				matched = append(matched, asset)
@@ -214,6 +223,19 @@ func newFakeHistorianServer(t *testing.T, fixture fakeHistorianData) *httptest.S
 	})
 
 	return httptest.NewServer(mux)
+}
+
+// indexedValues returns the values of indexed query parameters like "Foo[0]=a&Foo[1]=b"
+// in input order.
+func indexedValues(q url.Values, prefix string) []string {
+	var out []string
+	for i := 0; ; i++ {
+		v := q.Get(fmt.Sprintf("%s[%d]", prefix, i))
+		if v == "" {
+			return out
+		}
+		out = append(out, v)
+	}
 }
 
 // writeJSON encodes body to w. Encode errors here would mean a programming bug in the

--- a/pkg/datasource/events_test.go
+++ b/pkg/datasource/events_test.go
@@ -1,0 +1,241 @@
+package datasource
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/api"
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEventQueryResultToDataFrame_ParentAssetEnrichment is a builder-level contract test:
+// when the parent's asset is present in the slice handed to the data-frame builder, the
+// Parent_Asset and Parent_AssetPath fields populate correctly.
+func TestEventQueryResultToDataFrame_ParentAssetEnrichment(t *testing.T) {
+	t.Parallel()
+
+	parentAsset := schemas.Asset{
+		BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "machine"},
+		AssetPath: `\\site\\machine`,
+	}
+	childAsset := schemas.Asset{
+		BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "sensor"},
+		AssetPath: `\\site\\machine\\sensor`,
+	}
+	parentEventType := schemas.EventType{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "Batch"}}
+	childEventType := schemas.EventType{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "Phase"}}
+
+	startTime := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	parentStop := startTime.Add(2 * time.Hour)
+	childStop := startTime.Add(time.Hour)
+	parentUUID := uuid.New()
+	parentEvent := schemas.Event{
+		UUID:          parentUUID,
+		AssetUUID:     parentAsset.UUID,
+		EventTypeUUID: parentEventType.UUID,
+		StartTime:     startTime,
+		StopTime:      &parentStop,
+	}
+	childEvent := schemas.Event{
+		UUID:          uuid.New(),
+		AssetUUID:     childAsset.UUID,
+		EventTypeUUID: childEventType.UUID,
+		StartTime:     startTime,
+		StopTime:      &childStop,
+		ParentUUID:    &parentUUID,
+		Parent:        &parentEvent,
+	}
+
+	frames, err := EventQueryResultToDataFrame(
+		true,
+		false,
+		[]schemas.Asset{childAsset, parentAsset},
+		[]schemas.Event{childEvent},
+		[]schemas.EventType{childEventType, parentEventType},
+		nil,
+		map[string]struct{}{},
+		map[string]data.FieldType{},
+		map[uuid.UUID]data.Frames{},
+	)
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+
+	gotName := concreteString(t, frames[0], parentEventPrefix+AssetColumnName)
+	gotPath := concreteString(t, frames[0], parentEventPrefix+AssetPathColumnName)
+	gotUUID := concreteString(t, frames[0], parentEventPrefix+AssetUUIDColumnName)
+
+	assert.Equal(t, parentAsset.Name, gotName)
+	assert.Equal(t, parentAsset.AssetPath, gotPath)
+	assert.Equal(t, parentAsset.UUID.String(), gotUUID)
+}
+
+// TestHandleEventQuery_PopulatesParentAssetOutsideSelection is the regression test for
+// ticket 34763: when the user selects a leaf asset but enables "Include parent event",
+// the parent event's asset is not in the selected asset filter. The handler must still
+// populate Parent_Asset and Parent_AssetPath in the resulting frame.
+//
+// Without the fix in handleEventQuery, the asset map handed to the data-frame builder
+// only contains the user-selected child asset, so the parent asset name/path lookups
+// resolve to empty strings.
+func TestHandleEventQuery_PopulatesParentAssetOutsideSelection(t *testing.T) {
+	t.Parallel()
+
+	parentAsset := schemas.Asset{
+		BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "machine"},
+		AssetPath: `\\site\\machine`,
+	}
+	childAsset := schemas.Asset{
+		BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "sensor"},
+		AssetPath: `\\site\\machine\\sensor`,
+	}
+	parentEventType := schemas.EventType{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "Batch"}}
+	childEventType := schemas.EventType{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "Phase"}}
+
+	startTime := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	parentStop := startTime.Add(2 * time.Hour)
+	childStop := startTime.Add(time.Hour)
+	parentUUID := uuid.New()
+	parentEvent := schemas.Event{
+		UUID:          parentUUID,
+		AssetUUID:     parentAsset.UUID,
+		EventTypeUUID: parentEventType.UUID,
+		StartTime:     startTime,
+		StopTime:      &parentStop,
+	}
+	childEvent := schemas.Event{
+		UUID:          uuid.New(),
+		AssetUUID:     childAsset.UUID,
+		EventTypeUUID: childEventType.UUID,
+		StartTime:     startTime,
+		StopTime:      &childStop,
+		ParentUUID:    &parentUUID,
+		Parent:        &parentEvent,
+	}
+
+	server := newFakeHistorianServer(t, fakeHistorianData{
+		assetsByPath:    map[string]schemas.Asset{childAsset.AssetPath: childAsset},
+		assetsByUUID:    map[string]schemas.Asset{parentAsset.UUID.String(): parentAsset, childAsset.UUID.String(): childAsset},
+		eventTypesByKey: map[string]schemas.EventType{childEventType.Name: childEventType, childEventType.UUID.String(): childEventType, parentEventType.UUID.String(): parentEventType},
+		allEventTypes:   []schemas.EventType{childEventType, parentEventType},
+		events:          []schemas.Event{childEvent},
+	})
+	t.Cleanup(server.Close)
+
+	apiClient, err := api.NewAPIWithToken(server.URL, "test-token", "test-org")
+	require.NoError(t, err)
+	ds := &HistorianDataSource{API: apiClient}
+
+	historianInfo := &schemas.HistorianInfo{Version: "v7.0.0"}
+	eventQuery := schemas.EventQuery{
+		Type:              string(schemas.EventTypePropertyTypeSimple),
+		Assets:            []string{childAsset.AssetPath},
+		EventTypes:        []string{childEventType.Name},
+		IncludeParentInfo: true,
+	}
+	timeRange := backend.TimeRange{From: startTime.Add(-time.Hour), To: startTime.Add(24 * time.Hour)}
+
+	frames, err := ds.handleEventQuery(context.Background(), eventQuery, timeRange, time.Minute, 1000, historianInfo)
+	require.NoError(t, err)
+	require.Len(t, frames, 1, "expected one frame for the child event type")
+
+	gotName := concreteString(t, frames[0], parentEventPrefix+AssetColumnName)
+	gotPath := concreteString(t, frames[0], parentEventPrefix+AssetPathColumnName)
+	gotUUID := concreteString(t, frames[0], parentEventPrefix+AssetUUIDColumnName)
+
+	assert.Equal(t, parentAsset.Name, gotName, "Parent_Asset must reflect the parent event's asset name even when the parent's asset is outside the user-selected asset filter")
+	assert.Equal(t, parentAsset.AssetPath, gotPath, "Parent_AssetPath must reflect the parent event's asset path even when the parent's asset is outside the user-selected asset filter")
+	assert.Equal(t, parentAsset.UUID.String(), gotUUID)
+}
+
+// fakeHistorianData is a minimal in-memory representation of a Historian server's state,
+// keyed by the query parameters the datasource uses to look things up.
+type fakeHistorianData struct {
+	assetsByPath    map[string]schemas.Asset
+	assetsByUUID    map[string]schemas.Asset
+	eventTypesByKey map[string]schemas.EventType
+	allEventTypes   []schemas.EventType
+	events          []schemas.Event
+}
+
+// newFakeHistorianServer spins up an httptest.Server that serves only the endpoints the
+// event query handler touches, returning data based on the supplied filters.
+func newFakeHistorianServer(t *testing.T, fixture fakeHistorianData) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/assets", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		var matched []schemas.Asset
+		switch {
+		case q.Get("Path") != "":
+			if asset, ok := fixture.assetsByPath[q.Get("Path")]; ok {
+				matched = append(matched, asset)
+			}
+		case q.Get("Keyword") != "":
+			if asset, ok := fixture.assetsByUUID[q.Get("Keyword")]; ok {
+				matched = append(matched, asset)
+			}
+		default:
+			for _, asset := range fixture.assetsByPath {
+				matched = append(matched, asset)
+			}
+		}
+		writeJSON(w, matched)
+	})
+
+	mux.HandleFunc("/api/event-types", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if keyword := q.Get("Keyword"); keyword != "" {
+			if et, ok := fixture.eventTypesByKey[keyword]; ok {
+				writeJSON(w, []schemas.EventType{et})
+				return
+			}
+			writeJSON(w, []schemas.EventType{})
+			return
+		}
+		writeJSON(w, fixture.allEventTypes)
+	})
+
+	mux.HandleFunc("/api/events", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, fixture.events)
+	})
+
+	mux.HandleFunc("/api/event-type-properties", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, []schemas.EventTypeProperty{})
+	})
+
+	return httptest.NewServer(mux)
+}
+
+// writeJSON encodes body to w. Encode errors here would mean a programming bug in the
+// test fixture (the input types are always serializable), so we panic — net/http's
+// recoverer will abort the response and the production code's failed call will surface
+// as a test-goroutine assertion. Calling t.FailNow from this handler goroutine is
+// unsupported by testing.T.
+func writeJSON(w http.ResponseWriter, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		panic(err)
+	}
+}
+
+func concreteString(t *testing.T, frame *data.Frame, name string) string {
+	t.Helper()
+	field, idx := frame.FieldByName(name)
+	require.NotEqual(t, -1, idx, "missing field %q in frame %q", name, frame.Name)
+	require.GreaterOrEqual(t, field.Len(), 1, "field %q is empty", name)
+	v, _ := field.At(0).(*string)
+	if v == nil {
+		return ""
+	}
+	return *v
+}


### PR DESCRIPTION
## Summary

Bug 34763: when *Include parent event* is enabled in the events query editor, `Parent_AssetUUID` populates correctly but `Parent_Asset` and `Parent_AssetPath` come back empty.

The asset map handed to the data-frame builders was built only from the user-selected asset filter, so any parent event whose asset wasn't in the user's selection (the common case — leaf assets selected, parent event lives on the parent asset) couldn't be resolved to a name/path. The UUID column survived because it's read directly off the parent event, not the asset map.

The handler now collects parent `AssetUUID`s missing from the user-selected assets, fetches them via the existing `GetFilteredAssets` helper, and appends them to the slice passed to the data-frame builders. The `assets` map used for the asset-measurement query and `multipleAssetsSelected` flag is left untouched so those semantics don't change.

## Linked work item

[Bug 34763: Parent Asset Name and Path is Missing](https://dev.azure.com/factry/Historian/_workitems/edit/34763) (reported on v3.0.1)

## Test plan

- [x] `go test ./...` passes
- [x] New regression test `TestHandleEventQuery_PopulatesParentAssetOutsideSelection` exercises `handleEventQuery` end-to-end via an httptest fake Historian; verified to fail without the fix and pass with it.
- [x] New builder-level contract test `TestEventQueryResultToDataFrame_ParentAssetEnrichment` documents that the data-frame builder populates Parent_Asset / Parent_AssetPath when the asset is in the slice it receives.
- [ ] Manual verification on a real Historian: run an events query selecting only a leaf asset whose parent event lives on a parent asset, enable *Include parent event*, confirm `Parent_Asset` and `Parent_AssetPath` are populated for both Type=simple and Type=periodic.