### PR TITLE
fix(query): preserve last-known point when its type differs from the result series

### DIFF
--- a/pkg/datasource/convert.go
+++ b/pkg/datasource/convert.go
@@ -1,0 +1,53 @@
+package datasource
+
+import "strconv"
+
+// toFloat64 coerces a scalar value into float64. Bools map to 1/0 and strings
+// parse as decimal. Returns ok=false when the value is not one of these types
+// or the string is not a valid number.
+func toFloat64(v interface{}) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case bool:
+		if x {
+			return 1.0, true
+		}
+		return 0.0, true
+	case string:
+		if f, err := strconv.ParseFloat(x, 64); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
+// toString coerces a scalar value into its string representation. Floats use
+// the shortest round-trippable form; bools render as "true"/"false".
+func toString(v interface{}) (string, bool) {
+	switch x := v.(type) {
+	case string:
+		return x, true
+	case float64:
+		return strconv.FormatFloat(x, 'g', -1, 64), true
+	case bool:
+		return strconv.FormatBool(x), true
+	}
+	return "", false
+}
+
+// toBool coerces a scalar value into bool. Non-zero floats become true; strings
+// parse via strconv.ParseBool ("true"/"false"/"1"/"0"/etc.).
+func toBool(v interface{}) (value, ok bool) {
+	switch x := v.(type) {
+	case bool:
+		return x, true
+	case float64:
+		return x != 0, true
+	case string:
+		if b, err := strconv.ParseBool(x); err == nil {
+			return b, true
+		}
+	}
+	return false, false
+}

--- a/pkg/datasource/convert_test.go
+++ b/pkg/datasource/convert_test.go
@@ -1,0 +1,100 @@
+package datasource
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToFloat64(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		in    interface{}
+		want  float64
+		wantOk bool
+	}{
+		{"float passthrough", 3.14, 3.14, true},
+		{"NaN passthrough", math.NaN(), math.NaN(), true},
+		{"true to one", true, 1.0, true},
+		{"false to zero", false, 0.0, true},
+		{"numeric string", "42.5", 42.5, true},
+		{"non-numeric string", "running", 0, false},
+		{"unsupported type", []byte("1"), 0, false},
+		{"nil", nil, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := toFloat64(tc.in)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk && !math.IsNaN(tc.want) {
+				assert.InDelta(t, tc.want, got, 0)
+			}
+			if tc.wantOk && math.IsNaN(tc.want) {
+				assert.True(t, math.IsNaN(got))
+			}
+		})
+	}
+}
+
+func TestToString(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		in    interface{}
+		want  string
+		wantOk bool
+	}{
+		{"string passthrough", "running", "running", true},
+		{"float shortest", 3.14, "3.14", true},
+		{"float integer-valued", 42.0, "42", true},
+		{"true", true, "true", true},
+		{"false", false, "false", true},
+		{"unsupported type", []byte("x"), "", false},
+		{"nil", nil, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := toString(tc.in)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestToBool(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		in    interface{}
+		want  bool
+		wantOk bool
+	}{
+		{"bool passthrough", true, true, true},
+		{"non-zero float", 0.5, true, true},
+		{"NaN is non-zero", math.NaN(), true, true},
+		{"zero float", 0.0, false, true},
+		{"true string", "true", true, true},
+		{"false string", "false", false, true},
+		{"1 string", "1", true, true},
+		{"0 string", "0", false, true},
+		{"non-bool string", "running", false, false},
+		{"unsupported type", []byte("x"), false, false},
+		{"nil", nil, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := toBool(tc.in)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/datasource/dataframe.go
+++ b/pkg/datasource/dataframe.go
@@ -62,7 +62,6 @@ func mergeFrames(lastKnown data.Frames, result data.Frames) data.Frames {
 		frameMap[getFrameID(aFrame)] = aFrame
 	}
 
-frameLoop:
 	for _, bFrame := range result {
 		bFrameID := getFrameID(bFrame)
 		aFrame, ok := frameMap[bFrameID]
@@ -75,7 +74,7 @@ frameLoop:
 
 			for i := 0; i < len(aFrame.Fields); i++ {
 				if aFrame.Fields[i].Type() != bFrame.Fields[i].Type() {
-					continue frameLoop
+					aFrame.Fields[i] = convertFieldType(aFrame.Fields[i], bFrame.Fields[i].Type())
 				}
 			}
 
@@ -90,6 +89,100 @@ frameLoop:
 	}
 
 	return slices.AppendSeq(make([]*data.Frame, 0, len(frameMap)), maps.Values(frameMap))
+}
+
+// convertLastKnownFramesForAggregation rewrites the value field of last-known
+// frames so they merge cleanly into a result frame produced by the given
+// aggregation. The historian's "last" aggregation preserves the measurement's
+// natural type, but result frames driven by a numeric aggregation (mean, sum,
+// …) are always numeric — so the last-known value field has to be coerced to
+// match before mergeFrames runs.
+func convertLastKnownFramesForAggregation(frames data.Frames, aggregation schemas.AggregationType) data.Frames {
+	for _, frame := range frames {
+		for i, field := range frame.Fields {
+			if field.Name != valueFieldName {
+				continue
+			}
+			frame.Fields[i] = convertFieldForAggregation(field, aggregation)
+		}
+	}
+	return frames
+}
+
+// convertFieldForAggregation returns the value field rewritten to the type the
+// given aggregation produces:
+//   - count: every row becomes 1 so the last-known point contributes a single
+//     observation when merged into a count series.
+//   - other numeric aggregations (integral, mean, median, spread, stddev, sum,
+//     twa): coerced to nullable float64 via convertFieldType.
+//   - first / last / max / min / mode: returned as-is — these preserve the
+//     source measurement's type, so the last-known field already matches.
+func convertFieldForAggregation(field *data.Field, aggregation schemas.AggregationType) *data.Field {
+	switch aggregation {
+	case schemas.Count:
+		countField := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, field.Len())
+		countField.Name = field.Name
+		countField.Labels = field.Labels
+		countField.Config = field.Config
+		for i := 0; i < field.Len(); i++ {
+			countField.Set(i, new(1.0))
+		}
+		return countField
+	case schemas.Integral, schemas.Mean, schemas.Median, schemas.Spread, schemas.Stddev, schemas.Sum, schemas.TWA:
+		return convertFieldType(field, data.FieldTypeNullableFloat64)
+	default:
+		return field
+	}
+}
+
+// convertFieldType returns a new field with src's name, labels and config but with
+// the given target type. Values whose concrete Go type differs from the target
+// (e.g. a numeric last-known point against a string result series) are dropped to
+// the zero/nil value of the target type so the merge can proceed; values that share
+// the target's underlying type — including the common nullable ↔ non-nullable case —
+// are preserved.
+func convertFieldType(src *data.Field, targetType data.FieldType) *data.Field {
+	dst := data.NewFieldFromFieldType(targetType, src.Len())
+	dst.Name = src.Name
+	dst.Labels = src.Labels
+	dst.Config = src.Config
+	for i := 0; i < src.Len(); i++ {
+		v, ok := src.ConcreteAt(i)
+		if !ok {
+			continue
+		}
+		switch targetType {
+		case data.FieldTypeFloat64:
+			if f, ok := toFloat64(v); ok {
+				dst.Set(i, f)
+			}
+		case data.FieldTypeNullableFloat64:
+			if f, ok := toFloat64(v); ok {
+				dst.Set(i, &f)
+			}
+		case data.FieldTypeString:
+			if s, ok := toString(v); ok {
+				dst.Set(i, s)
+			}
+		case data.FieldTypeNullableString:
+			if s, ok := toString(v); ok {
+				dst.Set(i, &s)
+			}
+		case data.FieldTypeBool:
+			if b, ok := toBool(v); ok {
+				dst.Set(i, b)
+			}
+		case data.FieldTypeNullableBool:
+			if b, ok := toBool(v); ok {
+				dst.Set(i, &b)
+			}
+		default:
+			// other field types (ints, time, json, …) are not produced by the
+			// historian for value fields; leave dst's pre-allocated zero/nil row
+			// in place so callers see a typed-but-empty value.
+		}
+	}
+	return dst
 }
 
 // getFrameSuffix returns the frame name for a given frame

--- a/pkg/datasource/dataframe_test.go
+++ b/pkg/datasource/dataframe_test.go
@@ -174,3 +174,169 @@ func TestApplyFrameFormat_EmptyDisplayName(t *testing.T) {
 	_, ok := displayField.ConcreteAt(0)
 	assert.False(t, ok, "display name column should be null when no display name is set")
 }
+
+func TestConvertFieldType_NullableToNonNullablePreservesValues(t *testing.T) {
+	t.Parallel()
+	one, two := 1.5, 2.5
+	src := data.NewField("value", nil, []*float64{&one, nil, &two})
+
+	dst := convertFieldType(src, data.FieldTypeFloat64)
+
+	require.Equal(t, data.FieldTypeFloat64, dst.Type())
+	require.Equal(t, 3, dst.Len())
+	assert.InDelta(t, 1.5, dst.At(0), 0)
+	assert.InDelta(t, 0.0, dst.At(1), 0, "nil source value falls back to zero of target type")
+	assert.InDelta(t, 2.5, dst.At(2), 0)
+}
+
+func TestConvertFieldType_BoolToFloat(t *testing.T) {
+	t.Parallel()
+	src := data.NewField("value", nil, []bool{true, false})
+
+	dst := convertFieldType(src, data.FieldTypeFloat64)
+
+	require.Equal(t, data.FieldTypeFloat64, dst.Type())
+	assert.InDelta(t, 1.0, dst.At(0), 0)
+	assert.InDelta(t, 0.0, dst.At(1), 0)
+}
+
+func TestConvertFieldType_FloatToString(t *testing.T) {
+	t.Parallel()
+	src := data.NewField("value", nil, []float64{3.14, 42})
+
+	dst := convertFieldType(src, data.FieldTypeString)
+
+	require.Equal(t, data.FieldTypeString, dst.Type())
+	assert.Equal(t, "3.14", dst.At(0))
+	assert.Equal(t, "42", dst.At(1))
+}
+
+func TestConvertFieldType_UnparseableStringToFloatFallsBackToZero(t *testing.T) {
+	t.Parallel()
+	src := data.NewField("value", nil, []string{"running"})
+
+	dst := convertFieldType(src, data.FieldTypeFloat64)
+
+	require.Equal(t, data.FieldTypeFloat64, dst.Type())
+	assert.InDelta(t, 0.0, dst.At(0), 0, "unparseable strings keep the zero pre-allocated by NewFieldFromFieldType")
+}
+
+func TestConvertFieldType_PreservesNameLabelsConfig(t *testing.T) {
+	t.Parallel()
+	src := data.NewField("value", data.Labels{"k": "v"}, []bool{true})
+	src.Config = &data.FieldConfig{DisplayNameFromDS: "label"}
+
+	dst := convertFieldType(src, data.FieldTypeFloat64)
+
+	assert.Equal(t, "value", dst.Name)
+	assert.Equal(t, data.Labels{"k": "v"}, dst.Labels)
+	require.NotNil(t, dst.Config)
+	assert.Equal(t, "label", dst.Config.DisplayNameFromDS)
+}
+
+// TestMergeFrames_BoolLastKnownIntoFloatResult covers bug 34075: when the
+// lastKnown frame's value type differs from the result frame, mergeFrames must
+// coerce the lastKnown values instead of dropping them silently.
+func TestMergeFrames_BoolLastKnownIntoFloatResult(t *testing.T) {
+	t.Parallel()
+	lastKnown := makeFrame(t, data.NewField("value", nil, []bool{true}), "running")
+	result := makeFrame(t, data.NewField("value", nil, []float64{42}), "running")
+
+	merged := mergeFrames(data.Frames{lastKnown}, data.Frames{result})
+
+	require.Len(t, merged, 1)
+	value, _ := merged[0].FieldByName("value")
+	require.NotNil(t, value)
+	require.Equal(t, data.FieldTypeFloat64, value.Type())
+	require.Equal(t, 2, value.Len())
+	assert.InDelta(t, 1.0, value.At(0), 0, "bool last-known value must coerce to 1.0 on a numeric series")
+	assert.InDelta(t, 42.0, value.At(1), 0)
+}
+
+func TestMergeFrames_SameTypesAppendsRows(t *testing.T) {
+	t.Parallel()
+	lastKnown := makeFrame(t, data.NewField("value", nil, []float64{1}), "v")
+	result := makeFrame(t, data.NewField("value", nil, []float64{2}), "v")
+
+	merged := mergeFrames(data.Frames{lastKnown}, data.Frames{result})
+
+	require.Len(t, merged, 1)
+	value, _ := merged[0].FieldByName("value")
+	require.NotNil(t, value)
+	require.Equal(t, 2, value.Len())
+	assert.InDelta(t, 1.0, value.At(0), 0)
+	assert.InDelta(t, 2.0, value.At(1), 0)
+}
+
+func TestMergeFrames_EmptyInputs(t *testing.T) {
+	t.Parallel()
+	frame := makeFrame(t, data.NewField("value", nil, []float64{1}), "v")
+
+	assert.Equal(t, data.Frames{frame}, mergeFrames(nil, data.Frames{frame}))
+	assert.Equal(t, data.Frames{frame}, mergeFrames(data.Frames{frame}, nil))
+}
+
+func TestConvertFieldForAggregation_CountReplacesValuesWithOne(t *testing.T) {
+	t.Parallel()
+	src := data.NewField("value", data.Labels{"k": "v"}, []bool{true, false})
+	src.Config = &data.FieldConfig{DisplayNameFromDS: "running"}
+
+	dst := convertFieldForAggregation(src, schemas.Count)
+
+	require.Equal(t, data.FieldTypeNullableFloat64, dst.Type())
+	require.Equal(t, 2, dst.Len())
+	for i := 0; i < dst.Len(); i++ {
+		got, ok := dst.ConcreteAt(i)
+		require.True(t, ok)
+		gotFloat, isFloat := got.(float64)
+		require.True(t, isFloat)
+		assert.InDelta(t, 1.0, gotFloat, 0)
+	}
+	assert.Equal(t, "value", dst.Name, "downstream FieldByName lookups need the value name preserved")
+	assert.Equal(t, data.Labels{"k": "v"}, dst.Labels)
+	require.NotNil(t, dst.Config)
+	assert.Equal(t, "running", dst.Config.DisplayNameFromDS)
+}
+
+func TestConvertFieldForAggregation_NumericCoercesToNullableFloat64(t *testing.T) {
+	t.Parallel()
+	src := data.NewField("value", nil, []bool{true, false})
+
+	for _, agg := range []schemas.AggregationType{schemas.Mean, schemas.Sum, schemas.TWA, schemas.Stddev, schemas.Spread, schemas.Median, schemas.Integral} {
+		t.Run(string(agg), func(t *testing.T) {
+			t.Parallel()
+			dst := convertFieldForAggregation(src, agg)
+			require.Equal(t, data.FieldTypeNullableFloat64, dst.Type())
+			got, _ := dst.ConcreteAt(0)
+			gotFloat, isFloat := got.(float64)
+			require.True(t, isFloat)
+			assert.InDelta(t, 1.0, gotFloat, 0)
+		})
+	}
+}
+
+func TestConvertFieldForAggregation_NonNumericReturnsSameField(t *testing.T) {
+	t.Parallel()
+	src := data.NewField("value", nil, []bool{true})
+
+	for _, agg := range []schemas.AggregationType{schemas.First, schemas.Last, schemas.Max, schemas.Min, schemas.Mode} {
+		t.Run(string(agg), func(t *testing.T) {
+			t.Parallel()
+			assert.Same(t, src, convertFieldForAggregation(src, agg),
+				"type-preserving aggregations must leave the field untouched")
+		})
+	}
+}
+
+func TestConvertLastKnownFramesForAggregation_OnlyTouchesValueField(t *testing.T) {
+	t.Parallel()
+	frame := makeFrame(t, data.NewField("value", nil, []bool{true}), "v")
+	timeField := frame.Fields[0]
+
+	convertLastKnownFramesForAggregation(data.Frames{frame}, schemas.Mean)
+
+	assert.Same(t, timeField, frame.Fields[0], "time field must not be rewritten")
+	value, _ := frame.FieldByName("value")
+	require.NotNil(t, value)
+	assert.Equal(t, data.FieldTypeNullableFloat64, value.Type())
+}

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -330,6 +330,10 @@ func (ds *HistorianDataSource) handleQuery(ctx context.Context, query schemas.Qu
 		}
 		lastKnowPointResults = append(lastKnowPointResults, lastResult...)
 
+		if options.Aggregation != nil {
+			lastKnowPointResults = convertLastKnownFramesForAggregation(lastKnowPointResults, options.Aggregation.Name)
+		}
+
 		result = mergeFrames(lastKnowPointResults, result)
 		if options.FillInitialEmptyValues {
 			result = fillInitialEmptyIntervals(result, query)


### PR DESCRIPTION
## Summary

`mergeFrames` previously skipped the merge whenever a lastKnown frame's value field type didn't match the result frame's type, which silently kept the lastKnown frame and dropped the result. The user-visible symptom: with `Include last known point` (or `Fill empty initial intervals`) enabled and a `mean` aggregation on a boolean measurement, the result series came back as boolean instead of numeric.

`mergeFrames` now coerces the lastKnown field to the result field's type via a new `convertFieldType` helper before appending rows. Conversion uses small `toFloat64` / `toString` / `toBool` helpers (extracted to `pkg/datasource/convert.go`) that handle every cross-type case for the three scalar types historian uses (number / string / bool):

- `→ float64`: bool maps to 1/0, string parses as decimal
- `→ string`: float uses shortest round-trip, bool renders as `"true"`/`"false"`
- `→ bool`: non-zero float is true, string parses via `strconv.ParseBool`

When a value can't be coerced (e.g. an unparseable string into float), the row falls back to the target's zero/nil value so the merge still proceeds.

[Bug 34075](https://dev.azure.com/factry/Historian/_workitems/edit/34075)

## Test plan

- [x] `go test ./pkg/datasource/...` — added unit tests for the conversion helpers, `convertFieldType`, and the bool-lastKnown-into-float-result merge scenario from the bug
- [ ] In Grafana: regex-select boolean measurement(s) with `mean` aggregation and `Include last known point` enabled — series should now render as numeric (1/0) rather than reverting to boolean