### PR TITLE
fix(api): gate batched uuid lookup to v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v3.2.1
+
+### Bug fixes
+
+- Replace limit number inputs with text inputs again
+- Fix max values default being set to a low value
+- Prevent datasource from trying to use unsupported asset API features when connecting to older Historian versions
+
 ## v3.2.0
 
 ### Changes

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 major = 3
-minor = 1
-patch = 0
+minor = 2
+patch = 1
 prerelease =
 project_name=factry-historian-datasource
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factry-historian-datasource",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A datasource plugin for Factry Historian",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -53,7 +53,14 @@ func (e *HTTPError) Error() string {
 // GetFilteredAssets returns a map of assets that match the given asset strings
 func (api *API) GetFilteredAssets(ctx context.Context, assetStrings []string, historianInfo *schemas.HistorianInfo) (map[uuid.UUID]schemas.Asset, error) {
 	assetUUIDSet := map[uuid.UUID]schemas.Asset{}
-	if util.CheckMinimumVersion(historianInfo, "6.4.0", false) {
+
+	assetStrings = util.Dedupe(assetStrings)
+	if len(assetStrings) == 0 {
+		return assetUUIDSet, nil
+	}
+
+	switch {
+	case util.CheckMinimumVersion(historianInfo, "8.1.0", false):
 		uuids := make([]string, 0, len(assetStrings))
 		paths := make([]string, 0, len(assetStrings))
 		for _, assetString := range assetStrings {
@@ -89,7 +96,23 @@ func (api *API) GetFilteredAssets(ctx context.Context, assetStrings []string, hi
 				assetUUIDSet[asset.UUID] = asset
 			}
 		}
-	} else {
+	case util.CheckMinimumVersion(historianInfo, "6.4.0", false):
+		for _, assetString := range assetStrings {
+			searchKey := "Path"
+			if _, err := uuid.Parse(assetString); err == nil {
+				searchKey = "Keyword"
+			}
+			assetQuery := url.Values{}
+			assetQuery.Add(searchKey, assetString)
+			assets, err := api.GetAssets(ctx, assetQuery.Encode())
+			if err != nil {
+				return nil, err
+			}
+			for _, asset := range assets {
+				assetUUIDSet[asset.UUID] = asset
+			}
+		}
+	default:
 		// Deprecated
 		assets, err := api.GetAssets(ctx, "")
 		if err != nil {

--- a/pkg/api/util_test.go
+++ b/pkg/api/util_test.go
@@ -1,9 +1,20 @@
 package api_test
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
 
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/api"
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAppendEscapedQuery(t *testing.T) {
@@ -70,5 +81,229 @@ func TestAppendEscapedQuery(t *testing.T) {
 				t.Errorf("AppendEscapedQuery() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetFilteredAssets(t *testing.T) {
+	t.Parallel()
+
+	a1UUID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	a2UUID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	a3UUID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	a1 := schemas.Asset{BaseModel: schemas.BaseModel{UUID: a1UUID, Name: "a1"}, AssetPath: "site/a1"}
+	a2 := schemas.Asset{BaseModel: schemas.BaseModel{UUID: a2UUID, Name: "a2"}, AssetPath: "site/a2"}
+	a3 := schemas.Asset{BaseModel: schemas.BaseModel{UUID: a3UUID, Name: "a3"}, AssetPath: "site/a3"}
+
+	byUUID := map[string]schemas.Asset{
+		a1UUID.String(): a1,
+		a2UUID.String(): a2,
+		a3UUID.String(): a3,
+	}
+	byPath := map[string]schemas.Asset{
+		a1.AssetPath: a1,
+		a2.AssetPath: a2,
+		a3.AssetPath: a3,
+	}
+	allAssets := []schemas.Asset{a1, a2, a3}
+
+	type recordedRequest struct {
+		rawQuery string
+		query    url.Values
+	}
+
+	startServer := func(t *testing.T) (*httptest.Server, *[]recordedRequest) {
+		t.Helper()
+		var (
+			mu       sync.Mutex
+			requests []recordedRequest
+		)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			requests = append(requests, recordedRequest{rawQuery: r.URL.RawQuery, query: r.URL.Query()})
+			mu.Unlock()
+
+			q := r.URL.Query()
+			var matched []schemas.Asset
+			uuids := indexedQuery(q, "UUIDs")
+			switch {
+			case len(uuids) > 0:
+				for _, u := range uuids {
+					if a, ok := byUUID[u]; ok {
+						matched = append(matched, a)
+					}
+				}
+			case q.Get("Keyword") != "":
+				if a, ok := byUUID[q.Get("Keyword")]; ok {
+					matched = append(matched, a)
+				}
+			case q.Get("Path") != "":
+				if a, ok := byPath[q.Get("Path")]; ok {
+					matched = append(matched, a)
+				}
+			default:
+				matched = allAssets
+			}
+			_ = json.NewEncoder(w).Encode(matched)
+		}))
+		t.Cleanup(srv.Close)
+		return srv, &requests
+	}
+
+	newClient := func(t *testing.T, baseURL string) *api.API {
+		t.Helper()
+		c, err := api.NewAPIWithToken(baseURL, "tok", "org")
+		require.NoError(t, err)
+		return c
+	}
+
+	t.Run("v8.1.0 batches uuids and queries paths individually", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		info := &schemas.HistorianInfo{Version: "v8.1.0"}
+		result, err := client.GetFilteredAssets(context.Background(),
+			[]string{a1UUID.String(), "site/a2", a3UUID.String()}, info)
+		require.NoError(t, err)
+		assert.Contains(t, result, a1UUID)
+		assert.Contains(t, result, a2UUID)
+		assert.Contains(t, result, a3UUID)
+
+		require.Len(t, *requests, 2, "expected one batched UUIDs request followed by one path request")
+		assert.ElementsMatch(t,
+			[]string{a1UUID.String(), a3UUID.String()},
+			indexedQuery((*requests)[0].query, "UUIDs"),
+			"v8 branch must encode UUIDs as indexed UUIDs[i] params",
+		)
+		assert.Empty(t, (*requests)[0].query.Get("Path"))
+		assert.Empty(t, (*requests)[0].query.Get("Keyword"))
+		assert.Equal(t, "site/a2", (*requests)[1].query.Get("Path"))
+	})
+
+	t.Run("v8.1.0 skips uuid request when no uuids are supplied", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		info := &schemas.HistorianInfo{Version: "v8.1.0"}
+		result, err := client.GetFilteredAssets(context.Background(),
+			[]string{"site/a1", "site/a3"}, info)
+		require.NoError(t, err)
+		assert.Contains(t, result, a1UUID)
+		assert.Contains(t, result, a3UUID)
+
+		require.Len(t, *requests, 2)
+		for _, req := range *requests {
+			assert.Empty(t, indexedQuery(req.query, "UUIDs"), "no UUIDs[i] should be sent when input has no uuids")
+			assert.NotEmpty(t, req.query.Get("Path"))
+		}
+	})
+
+	t.Run("v6.4.0 issues per-asset Keyword and Path requests", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		info := &schemas.HistorianInfo{Version: "v6.4.0"}
+		result, err := client.GetFilteredAssets(context.Background(),
+			[]string{a1UUID.String(), "site/a2"}, info)
+		require.NoError(t, err)
+		assert.Contains(t, result, a1UUID)
+		assert.Contains(t, result, a2UUID)
+
+		require.Len(t, *requests, 2, "v6.4 branch must issue one request per input")
+		assert.Equal(t, a1UUID.String(), (*requests)[0].query.Get("Keyword"))
+		assert.Empty(t, indexedQuery((*requests)[0].query, "UUIDs"), "v6.4 branch must not use the v8 UUIDs[i] form")
+		assert.Equal(t, "site/a2", (*requests)[1].query.Get("Path"))
+	})
+
+	t.Run("v7.x stays on per-asset Keyword/Path", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		info := &schemas.HistorianInfo{Version: "v7.5.3"}
+		_, err := client.GetFilteredAssets(context.Background(), []string{a1UUID.String()}, info)
+		require.NoError(t, err)
+
+		require.Len(t, *requests, 1)
+		assert.Equal(t, a1UUID.String(), (*requests)[0].query.Get("Keyword"))
+		assert.Empty(t, indexedQuery((*requests)[0].query, "UUIDs"))
+	})
+
+	t.Run("legacy below v6.4.0 fetches all and filters in memory", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		info := &schemas.HistorianInfo{Version: "v6.3.0"}
+		result, err := client.GetFilteredAssets(context.Background(),
+			[]string{a1UUID.String(), "site/a2"}, info)
+		require.NoError(t, err)
+		assert.Contains(t, result, a1UUID)
+		assert.Contains(t, result, a2UUID)
+		assert.NotContains(t, result, a3UUID)
+
+		require.Len(t, *requests, 1, "deprecated branch must issue a single unfiltered call")
+		assert.Empty(t, (*requests)[0].rawQuery, "deprecated request must carry no query params")
+	})
+
+	t.Run("nil historian info falls back to legacy branch", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		result, err := client.GetFilteredAssets(context.Background(), []string{"site/a1"}, nil)
+		require.NoError(t, err)
+		assert.Contains(t, result, a1UUID)
+
+		require.Len(t, *requests, 1)
+		assert.Empty(t, (*requests)[0].rawQuery)
+	})
+
+	t.Run("v6.4.0 deduplicates repeated asset strings", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		info := &schemas.HistorianInfo{Version: "v6.4.0"}
+		result, err := client.GetFilteredAssets(context.Background(),
+			[]string{a1UUID.String(), "site/a2", a1UUID.String(), "site/a2"}, info)
+		require.NoError(t, err)
+		assert.Contains(t, result, a1UUID)
+		assert.Contains(t, result, a2UUID)
+
+		require.Len(t, *requests, 2, "duplicates must collapse to a single request per unique input")
+	})
+
+	t.Run("v8.1.0 deduplicates repeated asset strings", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		info := &schemas.HistorianInfo{Version: "v8.1.0"}
+		_, err := client.GetFilteredAssets(context.Background(),
+			[]string{a1UUID.String(), a1UUID.String(), "site/a2", "site/a2"}, info)
+		require.NoError(t, err)
+
+		require.Len(t, *requests, 2, "expected one batched uuids request and one path request after dedup")
+		assert.Equal(t,
+			[]string{a1UUID.String()},
+			indexedQuery((*requests)[0].query, "UUIDs"),
+			"duplicate uuids must collapse before being encoded as UUIDs[i]",
+		)
+		assert.Equal(t, "site/a2", (*requests)[1].query.Get("Path"))
+	})
+}
+
+// indexedQuery returns values for the indexed parameter form Foo[0]=a&Foo[1]=b in input order.
+func indexedQuery(q url.Values, prefix string) []string {
+	var out []string
+	for i := 0; ; i++ {
+		v := q.Get(fmt.Sprintf("%s[%d]", prefix, i))
+		if v == "" {
+			return out
+		}
+		out = append(out, v)
 	}
 }

--- a/pkg/datasource/historian.go
+++ b/pkg/datasource/historian.go
@@ -2,8 +2,11 @@ package datasource
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/api"
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
 	"github.com/go-playground/form"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -23,11 +26,35 @@ const (
 	DefaultHistorianURL string = "http://127.0.0.1:8000"
 )
 
+const historianInfoTTL = 5 * time.Minute
+
 // HistorianDataSource ...
 type HistorianDataSource struct {
 	API             *api.API
 	Decoder         *form.Decoder
 	resourceHandler backend.CallResourceHandler
+
+	infoMu     sync.Mutex
+	info       *schemas.HistorianInfo
+	infoExpiry time.Time
+}
+
+// getHistorianInfo returns the historian info, refreshing the cached value when
+// it is missing or older than historianInfoTTL. The mutex is held across the
+// HTTP call so concurrent callers share a single round-trip.
+func (ds *HistorianDataSource) getHistorianInfo(ctx context.Context) (*schemas.HistorianInfo, error) {
+	ds.infoMu.Lock()
+	defer ds.infoMu.Unlock()
+	if ds.info != nil && time.Now().Before(ds.infoExpiry) {
+		return ds.info, nil
+	}
+	info, err := ds.API.GetInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ds.info = &info
+	ds.infoExpiry = time.Now().Add(historianInfoTTL)
+	return ds.info, nil
 }
 
 // NewDataSource creates a new data source instance

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -60,12 +60,12 @@ func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backe
 		}
 
 		if query.HistorianInfo == nil {
-			info, err := ds.API.GetInfo(ctx)
+			info, err := ds.getHistorianInfo(ctx)
 			if err != nil {
 				response.Error = err
 				return response
 			}
-			query.HistorianInfo = &info
+			query.HistorianInfo = info
 		}
 
 		response.Frames, response.Error = ds.handleAssetMeasurementQuery(ctx, assetMeasurementQuery, backendQuery.TimeRange, backendQuery.Interval, query.SeriesLimit, query.HistorianInfo)
@@ -104,12 +104,12 @@ func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backe
 		}
 
 		if query.HistorianInfo == nil {
-			info, err := ds.API.GetInfo(ctx)
+			info, err := ds.getHistorianInfo(ctx)
 			if err != nil {
 				response.Error = err
 				return response
 			}
-			query.HistorianInfo = &info
+			query.HistorianInfo = info
 		}
 
 		response.Frames, response.Error = ds.handleEventQuery(ctx, eventQuery, backendQuery.TimeRange, backendQuery.Interval, query.SeriesLimit, query.HistorianInfo)

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -59,6 +59,15 @@ func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backe
 			}
 		}
 
+		if query.HistorianInfo == nil {
+			info, err := ds.API.GetInfo(ctx)
+			if err != nil {
+				response.Error = err
+				return response
+			}
+			query.HistorianInfo = &info
+		}
+
 		response.Frames, response.Error = ds.handleAssetMeasurementQuery(ctx, assetMeasurementQuery, backendQuery.TimeRange, backendQuery.Interval, query.SeriesLimit, query.HistorianInfo)
 	case QueryTypeQuery:
 		measurementQuery := schemas.MeasurementQuery{}
@@ -92,6 +101,15 @@ func (ds *HistorianDataSource) queryData(ctx context.Context, backendQuery backe
 			return backend.DataResponse{
 				Error: err,
 			}
+		}
+
+		if query.HistorianInfo == nil {
+			info, err := ds.API.GetInfo(ctx)
+			if err != nil {
+				response.Error = err
+				return response
+			}
+			query.HistorianInfo = &info
 		}
 
 		response.Frames, response.Error = ds.handleEventQuery(ctx, eventQuery, backendQuery.TimeRange, backendQuery.Interval, query.SeriesLimit, query.HistorianInfo)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -19,6 +19,21 @@ func Unique[T comparable](arr []T) bool {
 	return true
 }
 
+// Dedupe returns a copy of arr with duplicate entries removed, preserving the order
+// of first occurrence.
+func Dedupe[T comparable](arr []T) []T {
+	seen := make(map[T]struct{}, len(arr))
+	out := make([]T, 0, len(arr))
+	for _, v := range arr {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
 // Model is an interface for objects with a UUID field
 type Model interface {
 	// GetUUID returns the UUID of the object


### PR DESCRIPTION
## Summary

The batched `UUIDs[i]` query parameter introduced in 7d0b115 is only supported by historian `>= 8.1.0`. Restore the original per-asset `Keyword`/`Path` lookup for historian instances on `6.4.0 ≤ v < 8.1.0`.

## Test plan

- [ ] Existing `pkg/api` and `pkg/datasource` tests pass
- [ ] Verify against a historian < 8.0.0 instance