### PR TITLE
fix(query): avoid duplicate series when including last known point

### DIFF
--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -326,10 +326,11 @@ func (ds *HistorianDataSource) handleQuery(ctx context.Context, query schemas.Qu
 		lastKnowPointResults := data.Frames{}
 
 		if len(lastPointQuery.Tags) == 0 {
-			lastPointQuery.Tags = make(map[string]string)
-			lastPointQuery.Tags["status"] = "Good"
-
-			// If unfiltered query last point for each resulting data frame
+			// Unfiltered query: fetch the last known point for each result frame
+			// using that frame's own labels. A status filter is deliberately not
+			// applied here: the historian echoes any filter tag back as a groupby
+			// label, which would give the last-known frame a different identity than
+			// the result series and surface it as a spurious extra series.
 			for _, frame := range result {
 				getLastQueryForFrame := getLastQueryForFrame(frame, query)
 				lastResult, err := ds.API.MeasurementQuery(ctx, getLastQueryForFrame)
@@ -339,14 +340,15 @@ func (ds *HistorianDataSource) handleQuery(ctx context.Context, query schemas.Qu
 
 				lastKnowPointResults = append(lastKnowPointResults, lastResult...)
 			}
+		} else {
+			// Tag-filtered query: a single last-known query carrying the same tags
+			// merges cleanly into the filtered result series.
+			lastResult, err := ds.API.MeasurementQuery(ctx, lastPointQuery)
+			if err != nil {
+				return nil, err
+			}
+			lastKnowPointResults = append(lastKnowPointResults, lastResult...)
 		}
-
-		// OtherFrames
-		lastResult, err := ds.API.MeasurementQuery(ctx, lastPointQuery)
-		if err != nil {
-			return nil, err
-		}
-		lastKnowPointResults = append(lastKnowPointResults, lastResult...)
 
 		if options.Aggregation != nil {
 			lastKnowPointResults = convertLastKnownFramesForAggregation(lastKnowPointResults, options.Aggregation.Name)

--- a/pkg/datasource/query_handler_test.go
+++ b/pkg/datasource/query_handler_test.go
@@ -21,8 +21,7 @@ import (
 
 // queryResponseFrame builds a single frame carrying the metadata getFrameID relies on
 // (MeasurementUUID + optional groupby Labels) so it survives the arrow round-trip.
-func queryResponseFrame(t *testing.T, measurementUUID string, labels map[string]interface{}, values []float64) *data.Frame {
-	t.Helper()
+func queryResponseFrame(measurementUUID string, labels map[string]interface{}, values []float64) *data.Frame {
 	times := make([]time.Time, len(values))
 	for i := range values {
 		times[i] = time.Unix(int64(i*60), 0)
@@ -42,44 +41,54 @@ func queryResponseFrame(t *testing.T, measurementUUID string, labels map[string]
 	return frame
 }
 
+// writeFramesResponse marshals frames into the protobuf DataResponse the historian client
+// expects. Errors are surfaced as a 500 so the calling goroutine's MeasurementQuery returns
+// an error (testify must not be called from this handler goroutine).
+func writeFramesResponse(w http.ResponseWriter, frames data.Frames) {
+	arrowBytes, err := frames.MarshalArrow()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	out, err := proto.Marshal(&arrow_pb.DataResponse{Frames: arrowBytes})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = w.Write(out)
+}
+
 // TestHandleQuery_IncludeLastKnownPoint_NoTags_SingleSeries reproduces the duplicate-series bug:
 // with "include last known point" enabled and no tag filter, handleQuery must return a single
 // merged series. The historian echoes any query tag back as a groupby label, so the catch-all
 // status=Good last-known query (which should only run when the user supplied tags) produces a
 // spurious second series {status: Good}.
 func TestHandleQuery_IncludeLastKnownPoint_NoTags_SingleSeries(t *testing.T) {
+	t.Parallel()
+
 	var mu sync.Mutex
 	var queries []schemas.Query
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-
+		body, _ := io.ReadAll(r.Body)
 		var q schemas.Query
-		require.NoError(t, json.Unmarshal(body, &q))
+		_ = json.Unmarshal(body, &q)
 
 		mu.Lock()
 		queries = append(queries, q)
 		mu.Unlock()
 
-		var frames data.Frames
 		switch {
 		case q.Aggregation == nil:
 			// Main query: the real series, no groupby labels.
-			frames = data.Frames{queryResponseFrame(t, "uuid-1", nil, []float64{10, 20, 30})}
+			writeFramesResponse(w, data.Frames{queryResponseFrame("uuid-1", nil, []float64{10, 20, 30})})
 		case q.Tags["status"] == "Good":
 			// Catch-all last-known query: the historian echoes the status tag as a label.
-			frames = data.Frames{queryResponseFrame(t, "uuid-1", map[string]interface{}{"status": "Good"}, []float64{5})}
+			writeFramesResponse(w, data.Frames{queryResponseFrame("uuid-1", map[string]interface{}{"status": "Good"}, []float64{5})})
 		default:
 			// Per-frame last-known query: same identity as the main series.
-			frames = data.Frames{queryResponseFrame(t, "uuid-1", nil, []float64{5})}
+			writeFramesResponse(w, data.Frames{queryResponseFrame("uuid-1", nil, []float64{5})})
 		}
-
-		arrowBytes, err := frames.MarshalArrow()
-		require.NoError(t, err)
-		out, err := proto.Marshal(&arrow_pb.DataResponse{Frames: arrowBytes})
-		require.NoError(t, err)
-		_, _ = w.Write(out)
 	}))
 	defer srv.Close()
 
@@ -114,31 +123,25 @@ func TestHandleQuery_IncludeLastKnownPoint_NoTags_SingleSeries(t *testing.T) {
 // supplies tags, handleQuery issues exactly one last-known query carrying those tags (and no
 // per-frame queries).
 func TestHandleQuery_IncludeLastKnownPoint_WithTags_RunsSingleLastQuery(t *testing.T) {
+	t.Parallel()
+
 	var mu sync.Mutex
 	var lastQueries []schemas.Query
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-
+		body, _ := io.ReadAll(r.Body)
 		var q schemas.Query
-		require.NoError(t, json.Unmarshal(body, &q))
+		_ = json.Unmarshal(body, &q)
 
-		var frames data.Frames
 		if q.Aggregation == nil {
-			frames = data.Frames{queryResponseFrame(t, "uuid-1", nil, []float64{10, 20, 30})}
-		} else {
-			mu.Lock()
-			lastQueries = append(lastQueries, q)
-			mu.Unlock()
-			frames = data.Frames{queryResponseFrame(t, "uuid-1", nil, []float64{5})}
+			writeFramesResponse(w, data.Frames{queryResponseFrame("uuid-1", nil, []float64{10, 20, 30})})
+			return
 		}
 
-		arrowBytes, err := frames.MarshalArrow()
-		require.NoError(t, err)
-		out, err := proto.Marshal(&arrow_pb.DataResponse{Frames: arrowBytes})
-		require.NoError(t, err)
-		_, _ = w.Write(out)
+		mu.Lock()
+		lastQueries = append(lastQueries, q)
+		mu.Unlock()
+		writeFramesResponse(w, data.Frames{queryResponseFrame("uuid-1", nil, []float64{5})})
 	}))
 	defer srv.Close()
 

--- a/pkg/datasource/query_handler_test.go
+++ b/pkg/datasource/query_handler_test.go
@@ -1,0 +1,167 @@
+package datasource
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/api"
+	arrow_pb "github.com/factrylabs/factry-historian-datasource.git/pkg/proto"
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// queryResponseFrame builds a single frame carrying the metadata getFrameID relies on
+// (MeasurementUUID + optional groupby Labels) so it survives the arrow round-trip.
+func queryResponseFrame(t *testing.T, measurementUUID string, labels map[string]interface{}, values []float64) *data.Frame {
+	t.Helper()
+	times := make([]time.Time, len(values))
+	for i := range values {
+		times[i] = time.Unix(int64(i*60), 0)
+	}
+	frame := data.NewFrame("",
+		data.NewField("time", nil, times),
+		data.NewField(valueFieldName, nil, values),
+	)
+	custom := map[string]interface{}{
+		"MeasurementUUID": measurementUUID,
+		"MeasurementName": "Level",
+	}
+	if labels != nil {
+		custom["Labels"] = labels
+	}
+	frame.Meta = &data.FrameMeta{Custom: custom}
+	return frame
+}
+
+// TestHandleQuery_IncludeLastKnownPoint_NoTags_SingleSeries reproduces the duplicate-series bug:
+// with "include last known point" enabled and no tag filter, handleQuery must return a single
+// merged series. The historian echoes any query tag back as a groupby label, so the catch-all
+// status=Good last-known query (which should only run when the user supplied tags) produces a
+// spurious second series {status: Good}.
+func TestHandleQuery_IncludeLastKnownPoint_NoTags_SingleSeries(t *testing.T) {
+	var mu sync.Mutex
+	var queries []schemas.Query
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var q schemas.Query
+		require.NoError(t, json.Unmarshal(body, &q))
+
+		mu.Lock()
+		queries = append(queries, q)
+		mu.Unlock()
+
+		var frames data.Frames
+		switch {
+		case q.Aggregation == nil:
+			// Main query: the real series, no groupby labels.
+			frames = data.Frames{queryResponseFrame(t, "uuid-1", nil, []float64{10, 20, 30})}
+		case q.Tags["status"] == "Good":
+			// Catch-all last-known query: the historian echoes the status tag as a label.
+			frames = data.Frames{queryResponseFrame(t, "uuid-1", map[string]interface{}{"status": "Good"}, []float64{5})}
+		default:
+			// Per-frame last-known query: same identity as the main series.
+			frames = data.Frames{queryResponseFrame(t, "uuid-1", nil, []float64{5})}
+		}
+
+		arrowBytes, err := frames.MarshalArrow()
+		require.NoError(t, err)
+		out, err := proto.Marshal(&arrow_pb.DataResponse{Frames: arrowBytes})
+		require.NoError(t, err)
+		_, _ = w.Write(out)
+	}))
+	defer srv.Close()
+
+	client, err := api.NewAPIWithToken(srv.URL, "tok", "org")
+	require.NoError(t, err)
+	ds := &HistorianDataSource{API: client}
+
+	start := time.Unix(0, 0)
+	end := time.Unix(3600, 0)
+	query := schemas.Query{
+		MeasurementUUIDs: []string{"uuid-1"},
+		Start:            start,
+		End:              &end,
+	}
+	options := schemas.MeasurementQueryOptions{IncludeLastKnownPoint: true}
+
+	result, err := ds.handleQuery(context.Background(), query, options)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1, "include last known point with no tags must return a single merged series, not a spurious {status: Good} series")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, q := range queries {
+		if q.Aggregation != nil && q.Tags["status"] == "Good" {
+			t.Fatalf("catch-all last-known query with status=Good tag must not be issued when the query has no tags")
+		}
+	}
+}
+
+// TestHandleQuery_IncludeLastKnownPoint_WithTags_RunsSingleLastQuery verifies that when the user
+// supplies tags, handleQuery issues exactly one last-known query carrying those tags (and no
+// per-frame queries).
+func TestHandleQuery_IncludeLastKnownPoint_WithTags_RunsSingleLastQuery(t *testing.T) {
+	var mu sync.Mutex
+	var lastQueries []schemas.Query
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var q schemas.Query
+		require.NoError(t, json.Unmarshal(body, &q))
+
+		var frames data.Frames
+		if q.Aggregation == nil {
+			frames = data.Frames{queryResponseFrame(t, "uuid-1", nil, []float64{10, 20, 30})}
+		} else {
+			mu.Lock()
+			lastQueries = append(lastQueries, q)
+			mu.Unlock()
+			frames = data.Frames{queryResponseFrame(t, "uuid-1", nil, []float64{5})}
+		}
+
+		arrowBytes, err := frames.MarshalArrow()
+		require.NoError(t, err)
+		out, err := proto.Marshal(&arrow_pb.DataResponse{Frames: arrowBytes})
+		require.NoError(t, err)
+		_, _ = w.Write(out)
+	}))
+	defer srv.Close()
+
+	client, err := api.NewAPIWithToken(srv.URL, "tok", "org")
+	require.NoError(t, err)
+	ds := &HistorianDataSource{API: client}
+
+	start := time.Unix(0, 0)
+	end := time.Unix(3600, 0)
+	query := schemas.Query{
+		MeasurementUUIDs: []string{"uuid-1"},
+		Start:            start,
+		End:              &end,
+		Tags:             map[string]string{"line": "1"},
+	}
+	options := schemas.MeasurementQueryOptions{IncludeLastKnownPoint: true}
+
+	result, err := ds.handleQuery(context.Background(), query, options)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, lastQueries, 1, "exactly one last-known query must run when tags are supplied")
+	assert.Equal(t, "1", lastQueries[0].Tags["line"], "the last-known query must carry the user's tags")
+}


### PR DESCRIPTION
## Summary

When "include last known point" is enabled on a query with **no tag filter**, two series were returned where only one was expected (e.g. `Line 1\Mixer\Level` plus a spurious `Line 1\Mixer\Level {status: Good}`).

### Root cause

In `handleQuery` (`pkg/datasource/query_handler.go`), the last-known logic ran the per-frame queries inside `if len(lastPointQuery.Tags) == 0`, but the catch-all `lastPointQuery` ran **unconditionally** (the `// OtherFrames` block) with `Tags["status"] = "Good"`. The historian echoes that filter tag back as a groupby label, so the catch-all last-known frame got a `{status: Good}` label. In `mergeFrames`, frame identity is `measurementUUID + label suffix`, so it didn't match the real series and was appended as a second series.

This was introduced in `45cd4c5` ("Rework last known point and fill empty intervals"): the original single last-known call should have moved into an `else` branch but was left unconditional.

### Fix

- Gate the catch-all last-known query behind an `else` so it only runs for tag-filtered queries.
- Drop the `status=Good` filter. Filtering by status forces the historian to emit a `status` label that the result series lacks, which is the very cause of the mismatch. The per-frame path already inherits each frame's real labels and merges cleanly.

## Test plan

- [x] `TestHandleQuery_IncludeLastKnownPoint_NoTags_SingleSeries` — reproduces the bug (failed before, passes after); asserts a single merged series and that no `status=Good` catch-all query is issued.
- [x] `TestHandleQuery_IncludeLastKnownPoint_WithTags_RunsSingleLastQuery` — the tag-filtered path issues exactly one last-known query carrying the user's tags.
- [x] `go test ./...` green, `go vet ./pkg/datasource/` clean.

## Note

This removes the "last known point restricted to Good status" behavior for untagged queries. That behavior was only ever produced by the buggy catch-all and is fundamentally incompatible with clean merging (filtering by status adds a status label). If Good-only last points are required, it needs server-side support to filter without grouping, or stripping the echoed label before merge.

https://claude.ai/code/session_01Mye9FtiZbQt21VXPXaUo3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mye9FtiZbQt21VXPXaUo3x)_