### PR TITLE
Add isRegex check to all places where regex check is possible

### DIFF
--- a/src/QueryEditor/Assets.test.tsx
+++ b/src/QueryEditor/Assets.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { Assets } from './Assets'
+import { DataSource } from 'datasource'
+import { AssetMeasurementQuery } from 'types'
+
+jest.mock('@grafana/runtime', () => ({
+  getTemplateSrv: () => ({ getVariables: () => [] }),
+  config: { featureToggles: {} },
+}))
+
+jest.mock('@grafana/ui', () => ({
+  InlineField: ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div>
+      <label>{label}</label>
+      {children}
+    </div>
+  ),
+  InlineFieldRow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+// Cascader test double: surface initialLabel as an input value so we can assert
+// on the label Assets passes down.
+jest.mock('components/Cascader/Cascader', () => ({
+  __esModule: true,
+  default: ({ initialLabel }: { initialLabel: string }) => (
+    <input data-testid="assets" readOnly value={initialLabel} />
+  ),
+}))
+
+jest.mock('components/util/AssetPropertiesSelect', () => ({
+  AssetProperties: () => null,
+}))
+
+jest.mock('./QueryOptions', () => ({
+  QueryOptions: () => null,
+}))
+
+const createMockDatasource = () =>
+  ({
+    getAssets: jest.fn().mockResolvedValue([]),
+    getAssetProperties: jest.fn().mockResolvedValue([]),
+    multiSelectReplace: (value: string) => [value],
+  }) as unknown as DataSource
+
+const renderComponent = (assets: string[]) => {
+  const query: AssetMeasurementQuery = {
+    Assets: assets,
+    AssetProperties: [],
+    Options: { Tags: {} } as any,
+  } as AssetMeasurementQuery
+
+  return render(
+    <Assets
+      query={query}
+      seriesLimit={0}
+      datasource={createMockDatasource()}
+      appIsAlertingType={false}
+      templateVariables={[]}
+      onChangeAssetMeasurementQuery={jest.fn()}
+      onChangeSeriesLimit={jest.fn()}
+    />
+  )
+}
+
+describe('Assets', () => {
+  it('displays a regex asset instead of clearing it', async () => {
+    renderComponent(['/pump.*/'])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assets')).toHaveValue('/pump.*/')
+    })
+  })
+
+  it('displays a template variable asset', async () => {
+    renderComponent(['$myVar'])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assets')).toHaveValue('$myVar')
+    })
+  })
+})

--- a/src/QueryEditor/EventAssetProperties.test.tsx
+++ b/src/QueryEditor/EventAssetProperties.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { EventAssetProperties } from './EventAssetProperties'
+import { DataSource } from 'datasource'
+
+jest.mock('@grafana/runtime', () => ({
+  getTemplateSrv: () => ({ getVariables: () => [] }),
+  config: { featureToggles: {} },
+}))
+
+jest.mock('@grafana/ui', () => ({
+  InlineField: ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div>
+      <label>{label}</label>
+      {children}
+    </div>
+  ),
+  InlineFieldRow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+// Cascader test double: surface initialLabel as an input value so we can assert
+// on the label EventAssetProperties passes down.
+jest.mock('components/Cascader/Cascader', () => ({
+  __esModule: true,
+  default: ({ initialLabel }: { initialLabel: string }) => (
+    <input data-testid="override-assets" readOnly value={initialLabel} />
+  ),
+}))
+
+jest.mock('components/util/AssetPropertiesSelect', () => ({
+  AssetProperties: () => null,
+}))
+
+jest.mock('./QueryOptions', () => ({
+  QueryOptions: () => null,
+}))
+
+const createMockDatasource = () =>
+  ({
+    getAssets: jest.fn().mockResolvedValue([]),
+    getAssetProperties: jest.fn().mockResolvedValue([]),
+  }) as unknown as DataSource
+
+const renderComponent = (overrideAssets: string[]) =>
+  render(
+    <EventAssetProperties
+      datasource={createMockDatasource()}
+      seriesLimit={0}
+      selectedAssets={[]}
+      overrideAssets={overrideAssets}
+      selectedAssetProperties={[]}
+      queryType="simple"
+      queryOptions={{} as any}
+      tags={[]}
+      appIsAlertingType={false}
+      templateVariables={[]}
+      onChangeAssetMeasurementQuery={jest.fn()}
+      onChangeSeriesLimit={jest.fn()}
+    />
+  )
+
+describe('EventAssetProperties', () => {
+  it('displays a regex override asset instead of clearing it', async () => {
+    renderComponent(['/pump.*/'])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('override-assets')).toHaveValue('/pump.*/')
+    })
+  })
+
+  it('displays a template variable override asset', async () => {
+    renderComponent(['$myVar'])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('override-assets')).toHaveValue('$myVar')
+    })
+  })
+})

--- a/src/QueryEditor/EventAssetProperties.tsx
+++ b/src/QueryEditor/EventAssetProperties.tsx
@@ -158,6 +158,10 @@ export const EventAssetProperties = (props: Props): JSX.Element => {
       return props.overrideAssets[0]
     }
 
+    if (isRegex(props.overrideAssets[0])) {
+      return props.overrideAssets[0]
+    }
+
     return ''
   }
 

--- a/src/QueryEditor/EventFilter.test.tsx
+++ b/src/QueryEditor/EventFilter.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { EventFilter } from './EventFilter'
+import { DataSource } from 'datasource'
+import { EventQuery } from 'types'
+
+jest.mock('@grafana/runtime', () => ({
+  getTemplateSrv: () => ({ getVariables: () => [] }),
+  config: { featureToggles: {} },
+}))
+
+jest.mock('@grafana/ui', () => ({
+  InlineField: ({ label, children }: { label: string; children: React.ReactNode }) => (
+    <div>
+      <label>{label}</label>
+      {children}
+    </div>
+  ),
+  InlineFieldRow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Select: () => null,
+  MultiSelect: () => null,
+}))
+
+// Cascader test double: surface initialLabel as an input value so we can assert
+// on the label EventFilter passes down.
+jest.mock('components/Cascader/Cascader', () => ({
+  __esModule: true,
+  default: ({ initialLabel }: { initialLabel: string }) => (
+    <input data-testid="assets" readOnly value={initialLabel} />
+  ),
+}))
+
+jest.mock('components/TagsSection/TagsSection', () => ({
+  TagsSection: () => null,
+}))
+
+const createMockDatasource = () =>
+  ({
+    getAssets: jest.fn().mockResolvedValue([]),
+    getEventTypes: jest.fn().mockResolvedValue([]),
+    getEventTypeProperties: jest.fn().mockResolvedValue([]),
+    getEventConfigurations: jest.fn().mockResolvedValue([]),
+    multiSelectReplace: (value: string) => [value],
+    containsTemplate: () => false,
+    historianInfo: { Version: '' },
+  }) as unknown as DataSource
+
+const renderComponent = (assets: string[]) => {
+  const query: EventQuery = {
+    Assets: assets,
+    EventTypes: [],
+    Properties: [],
+    Statuses: [],
+    PropertyFilter: [],
+  } as unknown as EventQuery
+
+  return render(<EventFilter query={query} datasource={createMockDatasource()} onChangeQuery={jest.fn()} />)
+}
+
+describe('EventFilter', () => {
+  it('displays a regex asset instead of clearing it', async () => {
+    renderComponent(['/pump.*/'])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assets')).toHaveValue('/pump.*/')
+    })
+  })
+
+  it('displays a template variable asset', async () => {
+    renderComponent(['$myVar'])
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assets')).toHaveValue('$myVar')
+    })
+  })
+})

--- a/src/QueryEditor/EventFilter.tsx
+++ b/src/QueryEditor/EventFilter.tsx
@@ -397,6 +397,10 @@ export const EventFilter = (props: Props): JSX.Element => {
       return props.query.Assets[0]
     }
 
+    if (isRegex(props.query.Assets[0])) {
+      return props.query.Assets[0]
+    }
+
     return ''
   }
   const availableStatuses = (): Array<SelectableValue<string>> => {


### PR DESCRIPTION
Fixes the disappearing regex problem in all places where regex input is allowed, and adds component tests to validate the behavior.