### PR TITLE
feat(api): set identifying User-Agent on Historian requests

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,11 +6,35 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/build/buildinfo"
 )
+
+// clientName is the fallback plugin name used in the User-Agent header for dev
+// and test builds. Production builds take the name from the plugin.json "id"
+// the SDK embeds at compile time (see clientIdentifier).
+const clientName = "factry-historian-datasource"
 
 // API is used to communicate with the historian API
 type API struct {
 	client *http.Client
+}
+
+// clientIdentifier returns the "<name>/<version>" string sent in the User-Agent
+// header so Historian can attribute traffic by client type and version. Both
+// come from the build info the SDK embeds at compile time (name from
+// plugin.json "id", version from package.json) and fall back to clientName and
+// "unknown" for dev builds where the build info is absent.
+func clientIdentifier() string {
+	name, version := clientName, "unknown"
+	if info, err := buildinfo.GetBuildInfo(); err == nil {
+		if info.PluginID != "" {
+			name = info.PluginID
+		}
+		if info.Version != "" {
+			version = info.Version
+		}
+	}
+	return name + "/" + version
 }
 
 // baseURLRoundTripper wraps an http.RoundTripper to prepend a base URL to all requests
@@ -48,6 +72,7 @@ func NewAPIWithToken(baseURL string, token string, organization string) (*API, e
 	headers := http.Header{
 		"x-organization-uuid": []string{organization},
 		"Authorization":       []string{"Bearer " + token},
+		"User-Agent":          []string{clientIdentifier()},
 	}
 	parsedBaseURL, err := url.Parse(baseURL)
 	if err != nil {

--- a/pkg/api/util_test.go
+++ b/pkg/api/util_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 
@@ -366,6 +367,35 @@ func TestGetAssets(t *testing.T) {
 		assert.Nil(t, assets[0].HasEventConfigurations)
 		assert.Nil(t, assets[0].Ancestors)
 	})
+}
+
+func TestClientIdentificationHeaders(t *testing.T) {
+	t.Parallel()
+
+	var gotHeader http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Clone()
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := api.NewAPIWithToken(srv.URL, "tok", "org")
+	require.NoError(t, err)
+
+	_, err = client.GetAssets(context.Background(), "")
+	require.NoError(t, err)
+
+	// Historian attributes incoming traffic by client: every request carries an
+	// identifying User-Agent. Version is empty in tests (no build info), so
+	// assert the name prefix.
+	const prefix = "factry-historian-datasource/"
+	userAgent := gotHeader.Get("User-Agent")
+	assert.True(t, strings.HasPrefix(userAgent, prefix),
+		"User-Agent %q must identify the datasource", userAgent)
+
+	// The existing auth/org headers must keep flowing alongside the new one.
+	assert.Equal(t, "Bearer tok", gotHeader.Get("Authorization"))
+	assert.Equal(t, "org", gotHeader.Get("X-Organization-Uuid"))
 }
 
 // indexedQuery returns values for the indexed parameter form Foo[0]=a&Foo[1]=b in input order.


### PR DESCRIPTION
## What

The datasource backend now sends an identifying `User-Agent` on every request to the Historian API:

```
User-Agent: factry-historian-datasource/<version>
```

The version is read from the build info embedded at compile time (`buildinfo.GetBuildInfo()`), and falls back to `unknown` for dev/test builds where it is not set. A production `mage` build embeds the real version (e.g. `factry-historian-datasource/3.2.1`).

## Why

Incoming API calls are hard to differentiate by source: a customer's own integration looks identical to the datasource. With a distinct User-Agent, Historian can attribute traffic by client type and version, and anything without a recognised first-party identifier is an external integration by elimination.

This is the "datasource first" slice. Collectors and the Excel add-in are intended to follow the same `<name>/<version>` convention.

## Implementation

All Historian traffic originates from the single Go client in `pkg/api`. The `User-Agent` is added to the header set injected by the existing `baseURLRoundTripper`, so it covers query, resource, health and info calls. The frontend never calls Historian directly (it goes through the Grafana backend via `getResource`).

Imports the lightweight `build/buildinfo` subpackage, not the parent `build` package (which would pull mage into the runtime binary).

## Decision

Started with both a `User-Agent` and an `X-Factry-Client` custom header; per team discussion, settled on **User-Agent only**.

## Testing

- New `TestClientIdentificationHeaders` asserts the `User-Agent` prefix and that the existing auth/org headers still flow.
- Verified the version embeds correctly by inspecting a `mage build:backend` binary (`3.2.1`).
- `go build`, `go vet`, `gofmt`, and `go test ./pkg/...` all pass.

PBI 36057.