### PR TITLE
test+fix: 2026-07-03 bug audit; all 31 test-covered findings fixed (CI green)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -60,10 +60,26 @@ func (b *baseURLRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 
 	// Only modify relative URLs
 	if !req.URL.IsAbs() {
-		// Combine base URL with request path
+		// Combine base URL with request path. Join the escaped paths so
+		// percent-escaped segments (tag keys, UUIDs) survive the rewrite.
 		req.URL.Scheme = b.baseURL.Scheme
 		req.URL.Host = b.baseURL.Host
-		req.URL.Path = strings.TrimSuffix(b.baseURL.Path, "/") + "/" + strings.TrimPrefix(req.URL.Path, "/")
+		joinedEscaped := strings.TrimSuffix(b.baseURL.EscapedPath(), "/") + "/" + strings.TrimPrefix(req.URL.EscapedPath(), "/")
+		joined, err := url.PathUnescape(joinedEscaped)
+		if err != nil {
+			// EscapedPath always yields a valid encoding, so this should
+			// never happen; fall back to joining the decoded paths.
+			joined = strings.TrimSuffix(b.baseURL.Path, "/") + "/" + strings.TrimPrefix(req.URL.Path, "/")
+			joinedEscaped = joined
+		}
+		req.URL.Path = joined
+		// Per net/url convention, RawPath is only set when it differs from
+		// the default encoding of Path.
+		if joinedEscaped != joined {
+			req.URL.RawPath = joinedEscaped
+		} else {
+			req.URL.RawPath = ""
+		}
 	}
 	return b.next.RoundTrip(req)
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/build/buildinfo"
@@ -67,19 +68,38 @@ func (b *baseURLRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	return b.next.RoundTrip(req)
 }
 
-// NewAPIWithToken creates a new instance of API using a token
-func NewAPIWithToken(baseURL string, token string, organization string) (*API, error) {
+// Options describes how to configure the historian API client
+type Options struct {
+	URL                string
+	Token              string
+	Organization       string
+	Timeout            time.Duration
+	QueryTimeout       time.Duration
+	InsecureSkipVerify bool
+}
+
+// NewAPIWithOptions creates a new instance of API from the given options
+func NewAPIWithOptions(options Options) (*API, error) {
 	headers := http.Header{
-		"x-organization-uuid": []string{organization},
-		"Authorization":       []string{"Bearer " + token},
+		"x-organization-uuid": []string{options.Organization},
+		"Authorization":       []string{"Bearer " + options.Token},
 		"User-Agent":          []string{clientIdentifier()},
 	}
-	parsedBaseURL, err := url.Parse(baseURL)
+	parsedBaseURL, err := url.Parse(options.URL)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := httpclient.New(httpclient.Options{
+	timeouts := httpclient.DefaultTimeoutOptions
+	if options.QueryTimeout > 0 {
+		timeouts.Timeout = options.QueryTimeout
+	}
+	if options.Timeout > 0 {
+		timeouts.DialTimeout = options.Timeout
+	}
+
+	clientOptions := httpclient.Options{
+		Timeouts: &timeouts,
 		Middlewares: []httpclient.Middleware{
 			httpclient.MiddlewareFunc(func(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
 				return &baseURLRoundTripper{
@@ -89,11 +109,25 @@ func NewAPIWithToken(baseURL string, token string, organization string) (*API, e
 				}
 			}),
 		},
-	})
+	}
+	if options.InsecureSkipVerify {
+		clientOptions.TLS = &httpclient.TLSOptions{InsecureSkipVerify: true}
+	}
+
+	client, err := httpclient.New(clientOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	api := &API{client}
 	return api, nil
+}
+
+// NewAPIWithToken creates a new instance of API using a token
+func NewAPIWithToken(baseURL string, token string, organization string) (*API, error) {
+	return NewAPIWithOptions(Options{
+		URL:          baseURL,
+		Token:        token,
+		Organization: organization,
+	})
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,0 +1,42 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/api"
+	arrow_pb "github.com/factrylabs/factry-historian-datasource.git/pkg/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// baseURLRoundTripper rewrites req.URL.Path but must also update RawPath. When
+// the historian URL has a path prefix, a stale RawPath is discarded by Go's
+// URL.EscapedPath and percent-escaped segments are re-escaped from the decoded
+// Path, so a tag key like "a/b" (escaped as "a%2Fb" by GetTagValues) would
+// reach the server as two path segments.
+func TestBaseURLPrefixPreservesEscapedPathSegments(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+		body, err := proto.Marshal(&arrow_pb.DataResponse{})
+		assert.NoError(t, err)
+		w.Header().Set("Content-Type", "application/protobuf")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+
+	historianAPI, err := api.NewAPIWithToken(server.URL+"/historian", "token", "org")
+	require.NoError(t, err)
+
+	_, err = historianAPI.GetTagValues(context.Background(), "meas-uuid", "a/b")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/historian/api/timeseries/measurements/meas-uuid/tags/a%2Fb", gotPath,
+		"the escaped tag key must survive the base-URL path rewrite")
+}

--- a/pkg/datasource/dataframe.go
+++ b/pkg/datasource/dataframe.go
@@ -446,7 +446,7 @@ func setAssetFrameNames(frames data.Frames, assets map[uuid.UUID]schemas.Asset, 
 func fillInitialEmptyIntervals(frames data.Frames, query schemas.Query) data.Frames {
 	for _, frame := range frames {
 		valueField, _ := frame.FieldByName(valueFieldName)
-		if valueField == nil {
+		if valueField == nil || valueField.Len() == 0 {
 			continue
 		}
 
@@ -470,6 +470,9 @@ func fillInitialEmptyIntervals(frames data.Frames, query schemas.Query) data.Fra
 			}
 			if query.End == nil {
 				return frames
+			}
+			if query.Aggregation == nil {
+				continue
 			}
 			duration, err := time.ParseDuration(query.Aggregation.Period)
 			if err != nil {

--- a/pkg/datasource/dataframe.go
+++ b/pkg/datasource/dataframe.go
@@ -672,24 +672,32 @@ func setFieldConfig(frame *data.Frame, useEngineeringSpecs bool) {
 	}
 }
 
+func isGoodFrame(frame *data.Frame) bool {
+	if frame == nil || frame.Meta == nil {
+		return false
+	}
+
+	custom, ok := frame.Meta.Custom.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	labels, ok := custom["Labels"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	status, ok := labels["status"]
+	if !ok {
+		return false
+	}
+
+	return status == "Good"
+}
+
 func sortByStatus(frames data.Frames) data.Frames {
-	sort.Slice(frames, func(i, _ int) bool {
-		custom, ok := frames[i].Meta.Custom.(map[string]interface{})
-		if !ok {
-			return false
-		}
-
-		labels, ok := custom["Labels"].(map[string]interface{})
-		if !ok {
-			return false
-		}
-
-		status, ok := labels["status"]
-		if !ok {
-			return false
-		}
-
-		return status == "Good"
+	sort.SliceStable(frames, func(i, j int) bool {
+		return isGoodFrame(frames[i]) && !isGoodFrame(frames[j])
 	})
 	return frames
 }

--- a/pkg/datasource/dataframe.go
+++ b/pkg/datasource/dataframe.go
@@ -486,9 +486,17 @@ func fillInitialEmptyIntervals(frames data.Frames, query schemas.Query) data.Fra
 	return frames
 }
 
-func deleteFirstRow(frames data.Frames) data.Frames {
+// deleteFirstRow removes the first row of every frame whose ID is in
+// lastKnownFrameIDs, i.e. frames that had a last-known row prepended by
+// mergeFrames. Other frames keep their first real sample.
+func deleteFirstRow(frames data.Frames, lastKnownFrameIDs map[string]struct{}) data.Frames {
 	for _, frame := range frames {
-		frame.DeleteRow(0)
+		if _, ok := lastKnownFrameIDs[getFrameID(frame)]; !ok {
+			continue
+		}
+		if frame.Rows() > 0 {
+			frame.DeleteRow(0)
+		}
 	}
 	return frames
 }

--- a/pkg/datasource/dataframe.go
+++ b/pkg/datasource/dataframe.go
@@ -47,14 +47,30 @@ func getLabelsFromFrame(frame *data.Frame) map[string]interface{} {
 	return labels
 }
 
-// mergeFrames merges 2 set of frames based on the metadata and name of each frame
-func mergeFrames(lastKnown data.Frames, result data.Frames) data.Frames {
+// mergeFrames merges 2 set of frames based on the metadata and name of each
+// frame. It also returns the set of frame IDs that ended up with a last-known
+// row at row 0, so the caller can trim exactly those frames when the last-known
+// point must not be shown. A frame is reported only when a last-known row was
+// actually prepended: frames kept because of a field-count mismatch, or result
+// frames with no last-known counterpart, start with a real sample at row 0 and
+// are excluded.
+func mergeFrames(lastKnown data.Frames, result data.Frames) (merged data.Frames, prepended map[string]struct{}) {
+	prepended = map[string]struct{}{}
 	if len(lastKnown) == 0 {
-		return result
+		return result, prepended
+	}
+
+	// Every non-empty last-known frame contributes a last-known row at row 0.
+	// This holds for standalone last-known frames and for successful merges; the
+	// merge loop below removes any ID whose last-known frame is discarded.
+	for _, aFrame := range lastKnown {
+		if aFrame.Rows() > 0 {
+			prepended[getFrameID(aFrame)] = struct{}{}
+		}
 	}
 
 	if len(result) == 0 {
-		return lastKnown
+		return lastKnown, prepended
 	}
 
 	frameMap := make(map[string]*data.Frame)
@@ -69,6 +85,12 @@ func mergeFrames(lastKnown data.Frames, result data.Frames) data.Frames {
 			frameMap[bFrameID] = bFrame
 		} else {
 			if len(aFrame.Fields) != len(bFrame.Fields) {
+				// Shape mismatch: keep the fresh result frame instead of the
+				// stale last-known frame so real query data is never dropped.
+				// Row 0 is now a real sample, not a last-known point, so this
+				// frame must not be trimmed.
+				frameMap[bFrameID] = bFrame
+				delete(prepended, bFrameID)
 				continue
 			}
 
@@ -88,7 +110,7 @@ func mergeFrames(lastKnown data.Frames, result data.Frames) data.Frames {
 		}
 	}
 
-	return slices.AppendSeq(make([]*data.Frame, 0, len(frameMap)), maps.Values(frameMap))
+	return slices.AppendSeq(make([]*data.Frame, 0, len(frameMap)), maps.Values(frameMap)), prepended
 }
 
 // convertLastKnownFramesForAggregation rewrites the value field of last-known

--- a/pkg/datasource/dataframe_test.go
+++ b/pkg/datasource/dataframe_test.go
@@ -404,3 +404,16 @@ func TestFillInitialEmptyIntervalsNilAggregationDoesNotPanic(t *testing.T) {
 		})
 	})
 }
+
+// sortByStatus must tolerate a nil frame.Meta and use a valid stable ordering
+// instead of a comparator that ignores its second argument.
+func TestSortByStatusNilMetaDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	frameA := data.NewFrame("a", data.NewField("time", nil, []time.Time{}))
+	frameB := data.NewFrame("b", data.NewField("time", nil, []time.Time{}))
+	// Meta deliberately nil on both frames.
+	assert.NotPanics(t, func() {
+		sortByStatus(data.Frames{frameA, frameB})
+	})
+}

--- a/pkg/datasource/dataframe_test.go
+++ b/pkg/datasource/dataframe_test.go
@@ -376,3 +376,31 @@ func TestDeleteFirstRowEmptyFrameDoesNotPanic(t *testing.T) {
 		deleteFirstRow(data.Frames{empty}, map[string]struct{}{getFrameID(empty): {}})
 	})
 }
+
+// fillInitialEmptyIntervals must not panic on a zero-row frame
+// (valueField.ConcreteAt(0) without a length check).
+func TestFillInitialEmptyIntervalsEmptyFrameDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	empty := measurementFrame("m-empty", 0)
+	assert.NotPanics(t, func() {
+		fillInitialEmptyIntervals(data.Frames{empty}, schemas.Query{})
+	})
+}
+
+// fillInitialEmptyIntervals must not dereference query.Aggregation when it is
+// nil and a frame has exactly one row. FillInitialEmptyValues without an
+// aggregation is expressible in saved query JSON and via the HTTP API.
+func TestFillInitialEmptyIntervalsNilAggregationDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	oneRow := measurementFrame("m-one", 1)
+	end := time.Unix(3600, 0).UTC()
+	assert.NotPanics(t, func() {
+		fillInitialEmptyIntervals(data.Frames{oneRow}, schemas.Query{
+			Start: time.Unix(0, 0).UTC(),
+			End:   &end,
+			// Aggregation deliberately nil
+		})
+	})
+}

--- a/pkg/datasource/dataframe_test.go
+++ b/pkg/datasource/dataframe_test.go
@@ -242,7 +242,7 @@ func TestMergeFrames_BoolLastKnownIntoFloatResult(t *testing.T) {
 	lastKnown := makeFrame(t, data.NewField("value", nil, []bool{true}), "running")
 	result := makeFrame(t, data.NewField("value", nil, []float64{42}), "running")
 
-	merged := mergeFrames(data.Frames{lastKnown}, data.Frames{result})
+	merged, _ := mergeFrames(data.Frames{lastKnown}, data.Frames{result})
 
 	require.Len(t, merged, 1)
 	value, _ := merged[0].FieldByName("value")
@@ -258,7 +258,7 @@ func TestMergeFrames_SameTypesAppendsRows(t *testing.T) {
 	lastKnown := makeFrame(t, data.NewField("value", nil, []float64{1}), "v")
 	result := makeFrame(t, data.NewField("value", nil, []float64{2}), "v")
 
-	merged := mergeFrames(data.Frames{lastKnown}, data.Frames{result})
+	merged, _ := mergeFrames(data.Frames{lastKnown}, data.Frames{result})
 
 	require.Len(t, merged, 1)
 	value, _ := merged[0].FieldByName("value")
@@ -272,8 +272,10 @@ func TestMergeFrames_EmptyInputs(t *testing.T) {
 	t.Parallel()
 	frame := makeFrame(t, data.NewField("value", nil, []float64{1}), "v")
 
-	assert.Equal(t, data.Frames{frame}, mergeFrames(nil, data.Frames{frame}))
-	assert.Equal(t, data.Frames{frame}, mergeFrames(data.Frames{frame}, nil))
+	mergedFromResult, _ := mergeFrames(nil, data.Frames{frame})
+	assert.Equal(t, data.Frames{frame}, mergedFromResult)
+	mergedFromLastKnown, _ := mergeFrames(data.Frames{frame}, nil)
+	assert.Equal(t, data.Frames{frame}, mergedFromLastKnown)
 }
 
 func TestConvertFieldForAggregation_CountReplacesValuesWithOne(t *testing.T) {
@@ -353,7 +355,7 @@ func TestDeleteFirstRowKeepsFramesWithoutLastKnownPoint(t *testing.T) {
 	resultB := measurementFrame("m-b", 2) // no last-known counterpart
 
 	lastKnownFrameIDs := map[string]struct{}{getFrameID(lastKnown): {}}
-	merged := mergeFrames(data.Frames{lastKnown}, data.Frames{resultA, resultB})
+	merged, _ := mergeFrames(data.Frames{lastKnown}, data.Frames{resultA, resultB})
 	out := deleteFirstRow(merged, lastKnownFrameIDs)
 
 	var frameB *data.Frame
@@ -416,4 +418,52 @@ func TestSortByStatusNilMetaDoesNotPanic(t *testing.T) {
 	assert.NotPanics(t, func() {
 		sortByStatus(data.Frames{frameA, frameB})
 	})
+}
+
+// mergeFrames must not drop the entire result frame when the last-known frame
+// with the same ID has a different field count; the panel would otherwise
+// silently show only the stale last-known point.
+func TestMergeFramesFieldCountMismatchKeepsResultRows(t *testing.T) {
+	t.Parallel()
+
+	lastKnown := measurementFrame("m-a", 1)
+	result := measurementFrame("m-a", 2)
+	result.Fields = append(result.Fields, data.NewField("extra", nil, []*string{nil, nil}))
+
+	merged, _ := mergeFrames(data.Frames{lastKnown}, data.Frames{result})
+
+	totalRows := 0
+	for _, frame := range merged {
+		totalRows += frame.Rows()
+	}
+	assert.GreaterOrEqual(t, totalRows, 2,
+		"the main query result must not be discarded on a field-count mismatch with the last-known frame")
+}
+
+// mergeFrames reports the set of frames that actually received a last-known row
+// at row 0. A frame kept because of a field-count mismatch starts with a real
+// sample, so it must be excluded from that set and not trimmed by
+// deleteFirstRow.
+func TestMergeFramesFieldCountMismatchNotMarkedForTrimming(t *testing.T) {
+	t.Parallel()
+
+	// Same measurement UUID => same frame ID, but different field counts.
+	lastKnown := measurementFrame("m-a", 1)
+	lastKnown.Fields = append(lastKnown.Fields, data.NewField("extra", nil, []*float64{new(1.0)}))
+	result := measurementFrame("m-a", 2) // time + value only
+
+	merged, prepended := mergeFrames(data.Frames{lastKnown}, data.Frames{result})
+
+	_, marked := prepended[getFrameID(result)]
+	require.False(t, marked, "a frame kept because of a field-count mismatch carries no prepended last-known row")
+
+	out := deleteFirstRow(merged, prepended)
+	var frame *data.Frame
+	for _, f := range out {
+		if getMeasurementUUIDFromFrame(f) == "m-a" {
+			frame = f
+		}
+	}
+	require.NotNil(t, frame)
+	assert.Equal(t, 2, frame.Rows(), "a field-count-mismatch frame must keep its first real sample")
 }

--- a/pkg/datasource/dataframe_test.go
+++ b/pkg/datasource/dataframe_test.go
@@ -340,3 +340,39 @@ func TestConvertLastKnownFramesForAggregation_OnlyTouchesValueField(t *testing.T
 	require.NotNil(t, value)
 	assert.Equal(t, data.FieldTypeNullableFloat64, value.Type())
 }
+
+// With FillInitialEmptyValues enabled and IncludeLastKnownPoint disabled,
+// deleteFirstRow removes row 0 of every frame. A frame that got no last-known
+// point merged in (its measurement started recording inside the query window)
+// must not lose its first real sample.
+func TestDeleteFirstRowKeepsFramesWithoutLastKnownPoint(t *testing.T) {
+	t.Parallel()
+
+	lastKnown := measurementFrame("m-a", 1)
+	resultA := measurementFrame("m-a", 2)
+	resultB := measurementFrame("m-b", 2) // no last-known counterpart
+
+	lastKnownFrameIDs := map[string]struct{}{getFrameID(lastKnown): {}}
+	merged := mergeFrames(data.Frames{lastKnown}, data.Frames{resultA, resultB})
+	out := deleteFirstRow(merged, lastKnownFrameIDs)
+
+	var frameB *data.Frame
+	for _, frame := range out {
+		if getMeasurementUUIDFromFrame(frame) == "m-b" {
+			frameB = frame
+		}
+	}
+	require.NotNil(t, frameB)
+	assert.Equal(t, 2, frameB.Rows(),
+		"a frame that had no last-known point prepended must not lose its first real sample")
+}
+
+// deleteFirstRow must not panic on a zero-row frame.
+func TestDeleteFirstRowEmptyFrameDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	empty := measurementFrame("m-empty", 0)
+	assert.NotPanics(t, func() {
+		deleteFirstRow(data.Frames{empty}, map[string]struct{}{getFrameID(empty): {}})
+	})
+}

--- a/pkg/datasource/event_query_handler.go
+++ b/pkg/datasource/event_query_handler.go
@@ -206,7 +206,8 @@ func (ds *HistorianDataSource) handleEventAssetMeasurementQuery(ctx context.Cont
 		}
 
 		if len(assetMeasurementQuery.AssetProperties) == 0 || slices.Contains(assetMeasurementQuery.AssetProperties, assetProperty.UUID.String()) || slices.Contains(assetMeasurementQuery.AssetProperties, assetProperty.Name) {
-			if len(measurementUUIDs) >= seriesLimit {
+			// a non-positive seriesLimit means unlimited
+			if seriesLimit > 0 && len(measurementUUIDs) >= seriesLimit {
 				if _, ok := measurementUUIDs[assetProperty.MeasurementUUID.String()]; !ok {
 					break
 				}

--- a/pkg/datasource/events.go
+++ b/pkg/datasource/events.go
@@ -589,7 +589,7 @@ func dataFrameForEventType(includeParentInfo bool, multipleAssetsSelected bool, 
 	parentFieldsAdded := make(map[string]bool) // Track added fields for parent event types
 
 	for i := range events {
-		if events[i].ParentUUID != nil {
+		if events[i].ParentUUID != nil && events[i].Parent != nil {
 			if includeParentInfo {
 				parentEvent := *events[i].Parent
 				_, parentEventTypeExists := eventTypes[parentEvent.EventTypeUUID]

--- a/pkg/datasource/events.go
+++ b/pkg/datasource/events.go
@@ -384,7 +384,8 @@ func buildSimpleFieldsForEvent(prefix string, eventTypeProperties []schemas.Even
 		case schemas.EventTypePropertyDatatypeString:
 			parentField = data.NewField(parentPropertyFieldName, nil, []*string{})
 		default:
-			parentField = data.NewField(parentPropertyFieldName, nil, []interface{}{})
+			// Unknown datatypes fall back to a nullable string column
+			parentField = data.NewField(parentPropertyFieldName, nil, []*string{})
 		}
 		fields = append(fields, parentField)
 	}
@@ -578,7 +579,8 @@ func dataFrameForEventType(includeParentInfo bool, multipleAssetsSelected bool, 
 		case schemas.EventTypePropertyDatatypeString:
 			field = data.NewField(eventTypeProperty.Name, nil, []*string{})
 		default:
-			field = data.NewField(eventTypeProperty.Name, nil, []interface{}{})
+			// Unknown datatypes fall back to a nullable string column
+			field = data.NewField(eventTypeProperty.Name, nil, []*string{})
 		}
 
 		fields = append(fields, field)

--- a/pkg/datasource/events.go
+++ b/pkg/datasource/events.go
@@ -640,6 +640,7 @@ func dataFrameForEventType(includeParentInfo bool, multipleAssetsSelected bool, 
 					break
 				}
 				appendAssetPropertyValue(field, valueField.At(0))
+				break
 			}
 			if !found {
 				field.Append(nil)

--- a/pkg/datasource/events.go
+++ b/pkg/datasource/events.go
@@ -162,7 +162,7 @@ func EventQueryResultToTrendDataFrame(includeParentInfo bool, assets []schemas.A
 				labels[parentPrefix+StartTimeColumnName] = parentEvent.StartTime.Format(time.RFC3339)
 				labels[parentPrefix+StopTimeColumnName] = ""
 				if parentEvent.StopTime != nil {
-					eventLabels[parentPrefix+StopTimeColumnName] = parentEvent.StopTime.Format(time.RFC3339)
+					labels[parentPrefix+StopTimeColumnName] = parentEvent.StopTime.Format(time.RFC3339)
 				}
 				labels[parentPrefix+AssetUUIDColumnName] = parentEvent.AssetUUID.String()
 				labels[parentPrefix+AssetColumnName] = uuidToAssetMap[parentEvent.AssetUUID].Name

--- a/pkg/datasource/events_test.go
+++ b/pkg/datasource/events_test.go
@@ -328,3 +328,27 @@ func TestGetAssetPropertyFieldTypes_UsesNamedValueField(t *testing.T) {
 	assert.Equal(t, data.FieldTypeNullableFloat64, got["Pressure"],
 		"declared type must come from the named value field, not positional Fields[1]")
 }
+
+// dataFrameForEventType dereferences events[i].Parent guarded only by
+// ParentUUID != nil. An event whose parent is not embedded in the response
+// must not panic the query.
+func TestEventWithParentUUIDButNoParentDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	eventTypeUUID := uuid.New()
+	parentUUID := uuid.New()
+	events := []schemas.Event{{
+		UUID:          uuid.New(),
+		AssetUUID:     uuid.New(),
+		EventTypeUUID: eventTypeUUID,
+		StartTime:     time.Unix(0, 0).UTC(),
+		ParentUUID:    &parentUUID,
+		Parent:        nil, // parent not preloaded
+	}}
+	eventTypes := []schemas.EventType{{BaseModel: schemas.BaseModel{UUID: eventTypeUUID, Name: "batch"}}}
+
+	assert.NotPanics(t, func() {
+		_, _ = EventQueryResultToDataFrame(true, false, nil, events, eventTypes, nil,
+			map[string]struct{}{}, map[string]data.FieldType{}, map[uuid.UUID]data.Frames{})
+	})
+}

--- a/pkg/datasource/events_test.go
+++ b/pkg/datasource/events_test.go
@@ -464,3 +464,20 @@ func TestEventTableColumnsStayAlignedWithMultipleFramesPerProperty(t *testing.T)
 		assert.Equal(t, 1, count, "field %q must have exactly one row per event", name)
 	}
 }
+
+// buildSimpleFieldsForEvent must fall back to a nullable string column for
+// unknown property datatypes instead of building a []interface{} field that
+// data.NewField rejects with a panic. Any datatype value other than
+// number/boolean/string (legacy empty value, future historian datatype) would
+// otherwise panic every simple event query.
+func TestUnknownEventPropertyDatatypeDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		buildSimpleFieldsForEvent("", []schemas.EventTypeProperty{{
+			BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "when"},
+			Datatype:  "datetime", // not one of the three known datatypes
+			Type:      schemas.EventTypePropertyTypeSimple,
+		}}, nil)
+	})
+}

--- a/pkg/datasource/events_test.go
+++ b/pkg/datasource/events_test.go
@@ -352,3 +352,65 @@ func TestEventWithParentUUIDButNoParentDoesNotPanic(t *testing.T) {
 			map[string]struct{}{}, map[string]data.FieldType{}, map[uuid.UUID]data.Frames{})
 	})
 }
+
+// In EventQueryResultToTrendDataFrame the parent stop time must be written to
+// labels, not eventLabels, so the Parent_StopTime label on periodic property
+// columns carries the parent's stop time instead of being empty.
+func TestTrendFrameParentStopTimeLabel(t *testing.T) {
+	t.Parallel()
+
+	eventTypeUUID := uuid.New()
+	parentEventTypeUUID := uuid.New()
+	stopTime := time.Unix(500, 0).UTC()
+
+	parent := schemas.Event{
+		UUID:          uuid.New(),
+		AssetUUID:     uuid.New(),
+		EventTypeUUID: parentEventTypeUUID,
+		StartTime:     time.Unix(0, 0).UTC(),
+		StopTime:      &stopTime,
+	}
+	event := schemas.Event{
+		UUID:          uuid.New(),
+		AssetUUID:     uuid.New(),
+		EventTypeUUID: eventTypeUUID,
+		StartTime:     time.Unix(100, 0).UTC(),
+		Parent:        &parent,
+		Properties: &schemas.EventProperties{
+			Properties: schemas.Attributes{
+				"profile": map[string]interface{}{
+					"t": []interface{}{0.0, 1.0},
+					"v": []interface{}{1.0, 2.0},
+				},
+			},
+		},
+	}
+
+	eventTypes := map[uuid.UUID]schemas.EventType{
+		eventTypeUUID:       {BaseModel: schemas.BaseModel{UUID: eventTypeUUID, Name: "batch"}},
+		parentEventTypeUUID: {BaseModel: schemas.BaseModel{UUID: parentEventTypeUUID, Name: "order"}},
+	}
+	properties := map[uuid.UUID][]schemas.EventTypeProperty{
+		eventTypeUUID: {{
+			BaseModel:     schemas.BaseModel{UUID: uuid.New(), Name: "profile"},
+			Datatype:      schemas.EventTypePropertyDatatypeNumber,
+			Type:          schemas.EventTypePropertyTypePeriodic,
+			EventTypeUUID: eventTypeUUID,
+		}},
+	}
+
+	frames, err := EventQueryResultToTrendDataFrame(true, nil, []schemas.Event{event}, eventTypes,
+		properties, map[string]struct{}{}, map[uuid.UUID]data.Frames{}, false)
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+
+	var propertyField *data.Field
+	for _, field := range frames[0].Fields {
+		if field.Name != "Offset" {
+			propertyField = field
+		}
+	}
+	require.NotNil(t, propertyField, "expected a periodic property column")
+	assert.Equal(t, stopTime.Format(time.RFC3339), propertyField.Labels[parentEventPrefix+StopTimeColumnName],
+		"Parent_StopTime label must carry the parent's stop time")
+}

--- a/pkg/datasource/events_test.go
+++ b/pkg/datasource/events_test.go
@@ -414,3 +414,53 @@ func TestTrendFrameParentStopTimeLabel(t *testing.T) {
 	assert.Equal(t, stopTime.Format(time.RFC3339), propertyField.Labels[parentEventPrefix+StopTimeColumnName],
 		"Parent_StopTime label must carry the parent's stop time")
 }
+
+// The per-event asset-property fill loop must break after a successful append.
+// When one asset property yields multiple frames (e.g. GroupBy status produces
+// a Good and a Bad frame), the column must not get two values for one event row
+// and misalign the table.
+func TestEventTableColumnsStayAlignedWithMultipleFramesPerProperty(t *testing.T) {
+	t.Parallel()
+
+	eventTypeUUID := uuid.New()
+	eventUUID := uuid.New()
+	events := []schemas.Event{{
+		UUID:          eventUUID,
+		AssetUUID:     uuid.New(),
+		EventTypeUUID: eventTypeUUID,
+		StartTime:     time.Unix(0, 0).UTC(),
+	}}
+	eventTypes := []schemas.EventType{{BaseModel: schemas.BaseModel{UUID: eventTypeUUID, Name: "batch"}}}
+
+	makeAssetPropertyFrame := func(value float64, status string) *data.Frame {
+		frame := data.NewFrame("",
+			data.NewField("time", nil, []time.Time{time.Unix(10, 0).UTC()}),
+			data.NewField(valueFieldName, nil, []*float64{&value}),
+		)
+		frame.Meta = &data.FrameMeta{
+			Custom: map[string]interface{}{
+				"AssetProperty": "temperature",
+				"Labels":        map[string]interface{}{"status": status},
+			},
+		}
+		return frame
+	}
+
+	frames, err := EventQueryResultToDataFrame(false, false, nil, events, eventTypes, nil,
+		map[string]struct{}{},
+		map[string]data.FieldType{"temperature": data.FieldTypeNullableFloat64},
+		map[uuid.UUID]data.Frames{eventUUID: {
+			makeAssetPropertyFrame(1.0, "Good"),
+			makeAssetPropertyFrame(2.0, "Bad"),
+		}})
+	require.NoError(t, err)
+	require.Len(t, frames, 1)
+
+	rowCounts := map[string]int{}
+	for _, field := range frames[0].Fields {
+		rowCounts[field.Name] = field.Len()
+	}
+	for name, count := range rowCounts {
+		assert.Equal(t, 1, count, "field %q must have exactly one row per event", name)
+	}
+}

--- a/pkg/datasource/historian.go
+++ b/pkg/datasource/historian.go
@@ -2,6 +2,7 @@ package datasource
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"time"
 
@@ -67,7 +68,21 @@ func NewDataSource(_ context.Context, s backend.DataSourceInstanceSettings) (ins
 	historianDataSource := &HistorianDataSource{
 		Decoder: form.NewDecoder(),
 	}
-	historianDataSource.API, err = api.NewAPIWithToken(settings.URL, settings.Token, settings.Organization)
+	apiOptions := api.Options{
+		URL:                settings.URL,
+		Token:              settings.Token,
+		Organization:       settings.Organization,
+		InsecureSkipVerify: settings.InsecureSkipVerify,
+	}
+	// Timeout settings are stored as strings of seconds; keep the client
+	// defaults when they fail to parse.
+	if seconds, err := strconv.Atoi(settings.Timeout); err == nil && seconds > 0 {
+		apiOptions.Timeout = time.Duration(seconds) * time.Second
+	}
+	if seconds, err := strconv.Atoi(settings.QueryTimeout); err == nil && seconds > 0 {
+		apiOptions.QueryTimeout = time.Duration(seconds) * time.Second
+	}
+	historianDataSource.API, err = api.NewAPIWithOptions(apiOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datasource/historian_test.go
+++ b/pkg/datasource/historian_test.go
@@ -1,0 +1,37 @@
+package datasource
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tlsSkipVerify (and timeout) datasource settings are decoded in
+// LoadSettings and must be wired into the HTTP client, so a historian behind a
+// self-signed certificate is reachable when TLS verification is disabled in the
+// datasource config.
+func TestTLSSkipVerifySettingIsApplied(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Version":"v7.0.0","APIVersion":"v1"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	instance, err := NewDataSource(context.Background(), backend.DataSourceInstanceSettings{
+		JSONData:                []byte(`{"url":"` + server.URL + `","organization":"org","tlsSkipVerify":true}`),
+		DecryptedSecureJSONData: map[string]string{"token": "token"},
+	})
+	require.NoError(t, err)
+	ds, ok := instance.(*HistorianDataSource)
+	require.True(t, ok)
+
+	_, err = ds.API.GetInfo(context.Background())
+	assert.NoError(t, err, "tlsSkipVerify=true must allow connecting to a historian with a self-signed certificate")
+}

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -451,8 +451,11 @@ func fillQueryVariables(query string, databaseType string, timeRange backend.Tim
 
 	if databaseType == "Influx" {
 		timeFilter = fmt.Sprintf("time >= %vns AND time < %vns", timeRange.From.UnixNano(), timeRange.To.UnixNano())
-		intervalNano := interval.Nanoseconds()
-		intervalStr = fmt.Sprintf("TIME(%vns, %vns)", intervalNano, timeRange.From.UnixNano()%intervalNano)
+		// Callers that omit intervalMs (direct API queries, some alerting payloads)
+		// have a zero interval; guard the modulo to avoid a divide-by-zero panic.
+		if intervalNano := interval.Nanoseconds(); intervalNano > 0 {
+			intervalStr = fmt.Sprintf("TIME(%vns, %vns)", intervalNano, timeRange.From.UnixNano()%intervalNano)
+		}
 	}
 
 	query = strings.ReplaceAll(query, "$timeFilter", timeFilter)

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -359,13 +359,22 @@ func (ds *HistorianDataSource) handleQuery(ctx context.Context, query schemas.Qu
 			lastKnowPointResults = convertLastKnownFramesForAggregation(lastKnowPointResults, options.Aggregation.Name)
 		}
 
+		// Track which frames get a last-known row prepended, before mergeFrames
+		// mutates the last-known frames. Empty last-known frames prepend nothing.
+		framesWithLastKnownPoint := map[string]struct{}{}
+		for _, frame := range lastKnowPointResults {
+			if frame.Rows() > 0 {
+				framesWithLastKnownPoint[getFrameID(frame)] = struct{}{}
+			}
+		}
+
 		result = mergeFrames(lastKnowPointResults, result)
 		if options.FillInitialEmptyValues {
 			result = fillInitialEmptyIntervals(result, query)
 		}
 
 		if !options.IncludeLastKnownPoint {
-			result = deleteFirstRow(result)
+			result = deleteFirstRow(result, framesWithLastKnownPoint)
 		}
 	}
 	if options.ChangesOnly {

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -216,7 +216,8 @@ assetLoop:
 				selectedPropertyUUIDs[assetProperty.UUID] = struct{}{}
 				measurementUUIDs[assetProperty.MeasurementUUID.String()] = struct{}{}
 				measurementIndexToPropertyMap = append(measurementIndexToPropertyMap, assetProperty)
-				if len(measurementUUIDs) >= seriesLimit {
+				// a non-positive seriesLimit means unlimited
+				if seriesLimit > 0 && len(measurementUUIDs) >= seriesLimit {
 					break assetLoop
 				}
 			}
@@ -276,7 +277,10 @@ func (ds *HistorianDataSource) getMeasurements(ctx context.Context, measurementQ
 
 		measurementsQuery := url.Values{}
 		measurementsQuery.Set("Keyword", measurement)
-		measurementsQuery.Set("Limit", strconv.Itoa(seriesLimit))
+		// a non-positive seriesLimit means unlimited, don't ask the API to truncate
+		if seriesLimit > 0 {
+			measurementsQuery.Set("Limit", strconv.Itoa(seriesLimit))
+		}
 		for i, databaseUUID := range databaseUUIDs {
 			measurementsQuery.Set(fmt.Sprintf("DatabaseUUIDs[%v]", i), databaseUUID)
 		}

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -203,10 +203,17 @@ func (ds *HistorianDataSource) handleAssetMeasurementQuery(ctx context.Context, 
 		propertiesByAssetUUIDAndID[assetProperty.AssetUUID][assetProperty.UUID.String()] = assetProperty
 	}
 
+	selectedPropertyUUIDs := map[uuid.UUID]struct{}{}
+
 assetLoop:
 	for assetUUID := range assets {
 		for propertyName, assetProperty := range propertiesByAssetUUIDAndID[assetUUID] {
 			if len(assetMeasurementQuery.AssetProperties) == 0 || slices.Contains(assetMeasurementQuery.AssetProperties, propertyName) {
+				// each property is registered under both its name and its UUID, only select it once
+				if _, ok := selectedPropertyUUIDs[assetProperty.UUID]; ok {
+					continue
+				}
+				selectedPropertyUUIDs[assetProperty.UUID] = struct{}{}
 				measurementUUIDs[assetProperty.MeasurementUUID.String()] = struct{}{}
 				measurementIndexToPropertyMap = append(measurementIndexToPropertyMap, assetProperty)
 				if len(measurementUUIDs) >= seriesLimit {

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -363,16 +363,11 @@ func (ds *HistorianDataSource) handleQuery(ctx context.Context, query schemas.Qu
 			lastKnowPointResults = convertLastKnownFramesForAggregation(lastKnowPointResults, options.Aggregation.Name)
 		}
 
-		// Track which frames get a last-known row prepended, before mergeFrames
-		// mutates the last-known frames. Empty last-known frames prepend nothing.
-		framesWithLastKnownPoint := map[string]struct{}{}
-		for _, frame := range lastKnowPointResults {
-			if frame.Rows() > 0 {
-				framesWithLastKnownPoint[getFrameID(frame)] = struct{}{}
-			}
-		}
-
-		result = mergeFrames(lastKnowPointResults, result)
+		// mergeFrames reports which frames actually received a last-known row at
+		// row 0, so deleteFirstRow trims only those and never a frame's first
+		// real sample.
+		var framesWithLastKnownPoint map[string]struct{}
+		result, framesWithLastKnownPoint = mergeFrames(lastKnowPointResults, result)
 		if options.FillInitialEmptyValues {
 			result = fillInitialEmptyIntervals(result, query)
 		}

--- a/pkg/datasource/query_handler_test.go
+++ b/pkg/datasource/query_handler_test.go
@@ -37,3 +37,16 @@ func TestAssetMeasurementQueryWithoutPropertyFilterDoesNotDuplicateSeries(t *tes
 	require.NoError(t, err)
 	assert.Len(t, frames, 1, "one asset property backed by one measurement must produce exactly one series")
 }
+
+// fillQueryVariables computes UnixNano()%interval unconditionally.
+// backend.Query.Interval is 0 for API/alerting callers that omit intervalMs,
+// so every raw query from such a caller must not die on an integer divide by
+// zero.
+func TestFillQueryVariablesZeroIntervalDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	timeRange := backend.TimeRange{From: time.Unix(0, 0).UTC(), To: time.Unix(3600, 0).UTC()}
+	assert.NotPanics(t, func() {
+		fillQueryVariables("SELECT * FROM measurement WHERE $timeFilter", "Influx", timeRange, 0)
+	})
+}

--- a/pkg/datasource/query_handler_test.go
+++ b/pkg/datasource/query_handler_test.go
@@ -1,0 +1,39 @@
+package datasource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An asset measurement query without a property filter must not return every
+// series twice. Properties are registered under both name and UUID in
+// propertiesByAssetUUIDAndID and the selection loop iterates all map entries,
+// so without deduplication each property is appended twice to the property map
+// and setAssetFrameNames then duplicates the frame.
+func TestAssetMeasurementQueryWithoutPropertyFilterDoesNotDuplicateSeries(t *testing.T) {
+	t.Parallel()
+
+	assetUUID := uuid.New()
+	measurementUUID := uuid.New()
+	ds := assetQueryFixture(t, assetUUID, []schemas.AssetProperty{{
+		BaseModel:       schemas.BaseModel{UUID: uuid.New(), Name: "temperature"},
+		AssetUUID:       assetUUID,
+		MeasurementUUID: measurementUUID,
+	}})
+
+	timeRange := backend.TimeRange{From: time.Unix(0, 0).UTC(), To: time.Unix(3600, 0).UTC()}
+	frames, err := ds.handleAssetMeasurementQuery(context.Background(), schemas.AssetMeasurementQuery{
+		Assets:          []string{"plant"},
+		AssetProperties: []string{}, // no filter: query all properties of the asset
+	}, timeRange, time.Minute, 50, &schemas.HistorianInfo{Version: "v7.0.0"})
+
+	require.NoError(t, err)
+	assert.Len(t, frames, 1, "one asset property backed by one measurement must produce exactly one series")
+}

--- a/pkg/datasource/query_handler_test.go
+++ b/pkg/datasource/query_handler_test.go
@@ -50,3 +50,33 @@ func TestFillQueryVariablesZeroIntervalDoesNotPanic(t *testing.T) {
 		fillQueryVariables("SELECT * FROM measurement WHERE $timeFilter", "Influx", timeRange, 0)
 	})
 }
+
+// A query with seriesLimit 0 (older saved queries, alerting or API callers that
+// bypass the frontend default) must not be silently truncated to a single
+// series instead of returning all matching series.
+func TestSeriesLimitZeroDoesNotTruncateToOneSeries(t *testing.T) {
+	t.Parallel()
+
+	assetUUID := uuid.New()
+	ds := assetQueryFixture(t, assetUUID, []schemas.AssetProperty{
+		{
+			BaseModel:       schemas.BaseModel{UUID: uuid.New(), Name: "temperature"},
+			AssetUUID:       assetUUID,
+			MeasurementUUID: uuid.New(),
+		},
+		{
+			BaseModel:       schemas.BaseModel{UUID: uuid.New(), Name: "pressure"},
+			AssetUUID:       assetUUID,
+			MeasurementUUID: uuid.New(),
+		},
+	})
+
+	timeRange := backend.TimeRange{From: time.Unix(0, 0).UTC(), To: time.Unix(3600, 0).UTC()}
+	frames, err := ds.handleAssetMeasurementQuery(context.Background(), schemas.AssetMeasurementQuery{
+		Assets:          []string{"plant"},
+		AssetProperties: []string{"temperature", "pressure"},
+	}, timeRange, time.Minute, 0, &schemas.HistorianInfo{Version: "v7.0.0"})
+
+	require.NoError(t, err)
+	assert.Len(t, frames, 2, "seriesLimit 0 must not silently truncate the result to one series")
+}

--- a/pkg/datasource/resource_handler.go
+++ b/pkg/datasource/resource_handler.go
@@ -245,6 +245,10 @@ func (ds *HistorianDataSource) handleGetEventPropertyValues(_ http.ResponseWrite
 	if parsedUUID, err := uuid.Parse(eventTypeProperty); err == nil {
 		eventTypePropertyUUID = parsedUUID
 	} else {
+		if len(request.Properties) == 0 {
+			return nil, errors.New("a property name is required via the Properties parameter")
+		}
+
 		queryString := "Types[0]=" + request.Type + "&"
 		var queryStringBuilder strings.Builder
 		for i := range request.EventTypes {

--- a/pkg/datasource/resource_handler.go
+++ b/pkg/datasource/resource_handler.go
@@ -148,7 +148,7 @@ func (ds *HistorianDataSource) handleGetTagKeys(_ http.ResponseWriter, req *http
 	close(resultsChan)
 
 	for result := range resultsChan {
-		frames = mergeFrames(frames, result)
+		frames, _ = mergeFrames(frames, result)
 	}
 
 	return getStringSetFromFrames(frames, "tagKey"), nil
@@ -220,7 +220,7 @@ func (ds *HistorianDataSource) handleGetTagValues(_ http.ResponseWriter, req *ht
 	close(resultsChan)
 
 	for result := range resultsChan {
-		frames = mergeFrames(frames, result)
+		frames, _ = mergeFrames(frames, result)
 	}
 
 	return getStringSetFromFrames(frames, "value"), nil

--- a/pkg/datasource/resource_handler_test.go
+++ b/pkg/datasource/resource_handler_test.go
@@ -1,0 +1,36 @@
+package datasource
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// handleGetEventPropertyValues indexes request.Properties[0] without a length
+// check when the path value is not a UUID. Resource-handler panics are not
+// recovered by the SDK, so this must return an error instead of killing the
+// whole plugin process.
+func TestEventPropertyValuesWithoutPropertiesParamDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	historianMux := http.NewServeMux()
+	historianMux.HandleFunc("GET /api/event-type-properties", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, []schemas.EventTypeProperty{{
+			BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "other"},
+		}})
+	})
+	ds := newFakeHistorianDataSource(t, historianMux)
+
+	resourceMux := http.NewServeMux()
+	resourceMux.HandleFunc("GET /event-property-values/{uuid}", handleJSON(ds.handleGetEventPropertyValues))
+
+	req := httptest.NewRequest(http.MethodGet, "/event-property-values/someName", http.NoBody)
+	rec := httptest.NewRecorder()
+	assert.NotPanics(t, func() {
+		resourceMux.ServeHTTP(rec, req)
+	}, "a resource call without Properties[0] must return an error, not kill the plugin process")
+}

--- a/pkg/datasource/testhelpers_test.go
+++ b/pkg/datasource/testhelpers_test.go
@@ -1,0 +1,101 @@
+package datasource
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/api"
+	arrow_pb "github.com/factrylabs/factry-historian-datasource.git/pkg/proto"
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/go-playground/form"
+	"github.com/google/uuid"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// measurementFrame builds a frame in the shape the historian returns for a
+// timeseries query: a time and a value column plus the standard custom meta.
+func measurementFrame(measurementUUID string, rows int) *data.Frame {
+	times := make([]time.Time, 0, rows)
+	values := make([]*float64, 0, rows)
+	for i := range rows {
+		times = append(times, time.Unix(int64(60*i), 0).UTC())
+		values = append(values, new(float64(i)))
+	}
+	frame := data.NewFrame("",
+		data.NewField("time", nil, times),
+		data.NewField(valueFieldName, nil, values),
+	)
+	frame.Meta = &data.FrameMeta{
+		Custom: map[string]interface{}{
+			"MeasurementUUID": measurementUUID,
+			"MeasurementName": "measurement-" + measurementUUID,
+			"DatabaseName":    "factory",
+			"Labels":          map[string]interface{}{},
+		},
+	}
+	return frame
+}
+
+// newFakeHistorianDataSource spins up a fake historian HTTP server and returns
+// a HistorianDataSource whose API client points at it.
+func newFakeHistorianDataSource(t *testing.T, mux *http.ServeMux) *HistorianDataSource {
+	t.Helper()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	historianAPI, err := api.NewAPIWithToken(server.URL, "token", "org")
+	require.NoError(t, err)
+
+	return &HistorianDataSource{
+		API:     historianAPI,
+		Decoder: form.NewDecoder(),
+	}
+}
+
+func writeArrowResponse(t *testing.T, w http.ResponseWriter, frames data.Frames) {
+	t.Helper()
+	encoded := make([][]byte, 0, len(frames))
+	for _, frame := range frames {
+		b, err := frame.MarshalArrow()
+		require.NoError(t, err)
+		encoded = append(encoded, b)
+	}
+	body, err := proto.Marshal(&arrow_pb.DataResponse{Frames: encoded})
+	require.NoError(t, err)
+	w.Header().Set("Content-Type", "application/protobuf")
+	_, err = w.Write(body)
+	require.NoError(t, err)
+}
+
+// assetQueryFixture wires up a fake historian with one asset and the given
+// asset properties. The timeseries endpoint returns one frame per requested
+// measurement UUID.
+func assetQueryFixture(t *testing.T, assetUUID uuid.UUID, properties []schemas.AssetProperty) *HistorianDataSource {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/assets", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, []schemas.Asset{{
+			BaseModel: schemas.BaseModel{UUID: assetUUID, Name: "plant"},
+			AssetPath: "plant",
+		}})
+	})
+	mux.HandleFunc("GET /api/asset-properties", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, properties)
+	})
+	mux.HandleFunc("POST /api/timeseries/query", func(w http.ResponseWriter, r *http.Request) {
+		query := schemas.Query{}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&query))
+		frames := data.Frames{}
+		for _, measurementUUID := range query.MeasurementUUIDs {
+			frames = append(frames, measurementFrame(measurementUUID, 2))
+		}
+		writeArrowResponse(t, w, frames)
+	})
+	return newFakeHistorianDataSource(t, mux)
+}

--- a/pkg/datasource/util.go
+++ b/pkg/datasource/util.go
@@ -51,10 +51,9 @@ func handleJSON(f func(http.ResponseWriter, *http.Request) (interface{}, error))
 			return
 		}
 		// Set the content type and write the response
+		rw.Header().Set("Content-Type", "application/json")
 		if _, err := rw.Write(jsonResponse); err != nil {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 		}
-		rw.Header().Set("Content-Type", "application/json")
-		rw.WriteHeader(http.StatusOK)
 	}
 }

--- a/pkg/datasource/util_test.go
+++ b/pkg/datasource/util_test.go
@@ -1,0 +1,31 @@
+package datasource
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// handleJSON must set the Content-Type header before writing the body, so
+// resource responses are served as application/json instead of being
+// content-sniffed as text/plain.
+func TestResourceResponsesHaveJSONContentType(t *testing.T) {
+	t.Parallel()
+
+	handler := handleJSON(func(_ http.ResponseWriter, _ *http.Request) (interface{}, error) {
+		return []string{"a", "b"}, nil
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+}

--- a/pkg/util/periodic_property_values.go
+++ b/pkg/util/periodic_property_values.go
@@ -168,7 +168,9 @@ func (p *PeriodicPropertyValues) UnmarshalJSON(data []byte) error {
 	}
 
 	for i := range v.Offsets {
-		p.ValuesByOffset[v.Offsets[i]] = v.Values[i]
+		if len(v.Values) > i {
+			p.ValuesByOffset[v.Offsets[i]] = v.Values[i]
+		}
 		if len(v.DimensionValues) > i {
 			p.DimensionValuesByOffset[v.Offsets[i]] = v.DimensionValues[i]
 		}

--- a/pkg/util/periodic_property_values_test.go
+++ b/pkg/util/periodic_property_values_test.go
@@ -1,0 +1,24 @@
+package util_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+// PeriodicPropertyValues.UnmarshalJSON indexes v.Values[i] for every offset
+// without a bounds check, while DimensionValues one line below is
+// bounds-checked. A periodic property payload with more "t" entries than "v"
+// entries must not panic the event query.
+func TestPeriodicPropertyValuesLengthMismatchDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		p := util.PeriodicPropertyValues{}
+		// Malformed payload: 2 offsets, 1 value. Must return an error (or skip
+		// the missing entry), not panic.
+		_ = json.Unmarshal([]byte(`{"t":[0,1],"v":[10]}`), &p)
+	})
+}

--- a/pkg/util/semver.go
+++ b/pkg/util/semver.go
@@ -72,16 +72,11 @@ func comparePreRelease(a, b string) int {
 	aParts := strings.Split(a, ".")
 	bParts := strings.Split(b, ".")
 
-	maxLen := max(len(bParts), len(aParts))
+	minLen := min(len(aParts), len(bParts))
 
-	for i := range maxLen {
-		var aPart, bPart string
-		if i < len(aParts) {
-			aPart = aParts[i]
-		}
-		if i < len(bParts) {
-			bPart = bParts[i]
-		}
+	for i := range minLen {
+		aPart := aParts[i]
+		bPart := bParts[i]
 
 		aIsNum := isNumeric(aPart)
 		bIsNum := isNumeric(bPart)
@@ -105,7 +100,8 @@ func comparePreRelease(a, b string) int {
 		}
 	}
 
-	return 0
+	// All shared identifiers are equal: the larger set has higher precedence.
+	return len(aParts) - len(bParts)
 }
 
 // SemverCompare compares two semantic versions

--- a/pkg/util/semver_test.go
+++ b/pkg/util/semver_test.go
@@ -21,7 +21,7 @@ func TestSemverCompare(t *testing.T) {
 		{"1.10.0", "1.2.0", false},
 		{"1.0.0", "1.0.0-alpha", false},
 		{"1.0.0-alpha", "1.0.0", true},
-		{"1.0.0-alpha.1", "1.0.0-alpha", true},
+		{"1.0.0-alpha.1", "1.0.0-alpha", false},
 		{"1.0.0-alpha.1", "1.0.0-beta", true},
 	}
 
@@ -31,4 +31,17 @@ func TestSemverCompare(t *testing.T) {
 			assert.Equal(t, tt.expected, result < 0)
 		})
 	}
+}
+
+// comparePreRelease must not pad the shorter pre-release with "" (non-numeric),
+// which would invert SemVer precedence. Per spec item 11.4,
+// 1.0.0-alpha < 1.0.0-alpha.1: a larger identifier set wins when the shared
+// prefix is equal.
+func TestSemverPreReleasePrecedence(t *testing.T) {
+	t.Parallel()
+
+	assert.Negative(t, util.SemverCompare("1.0.0-alpha", "1.0.0-alpha.1"),
+		"1.0.0-alpha must be lower precedence than 1.0.0-alpha.1")
+	assert.Positive(t, util.SemverCompare("1.0.0-alpha.1", "1.0.0-alpha"),
+		"1.0.0-alpha.1 must be higher precedence than 1.0.0-alpha")
 }

--- a/src/components/TagsSection/Tag.tsx
+++ b/src/components/TagsSection/Tag.tsx
@@ -7,11 +7,11 @@ import { KnownCondition, KnownOperator, operatorsWithoutValue } from '../../util
 import { getCondition, getOperator, isRegex, toSelectableValue } from './util'
 
 function adjustOperatorIfNeeded(currentOperator: string, newTagValue: string): string {
-  const isCurrentOperatorRegex = currentOperator === '=~' || currentOperator === '!~'
+  const isCurrentOperatorRegex = currentOperator === '~' || currentOperator === '!~'
   const isNewTagValueRegex = isRegex(newTagValue)
 
   if (isNewTagValueRegex) {
-    return isCurrentOperatorRegex ? currentOperator : '=~'
+    return isCurrentOperatorRegex ? currentOperator : '~'
   } else {
     return isCurrentOperatorRegex ? '=' : currentOperator
   }

--- a/src/components/TagsSection/util.test.ts
+++ b/src/components/TagsSection/util.test.ts
@@ -1,0 +1,10 @@
+import { getOperator } from './util'
+
+// getOperator must not default to '=~' for regex-looking values: '=~' is not in
+// the plugin's operator vocabulary (KnownOperator supports '~'), so it would
+// reach the historian with an operator the plugin never offers.
+describe('getOperator maps regex values to a supported operator', () => {
+  it("uses '~' (not '=~') for regex-looking values", () => {
+    expect(getOperator({ key: 'k', value: '/motor.*/' })).toBe('~')
+  })
+})

--- a/src/components/TagsSection/util.ts
+++ b/src/components/TagsSection/util.ts
@@ -6,7 +6,7 @@ export function toSelectableValue<T extends string>(t: T): SelectableValue<T> {
 }
 
 export function getOperator(tag: QueryTag): string {
-  return tag.operator ?? (isRegex(tag.value) ? '=~' : '=')
+  return tag.operator ?? (isRegex(tag.value) ? '~' : '=')
 }
 
 export function getCondition(tag: QueryTag, isFirst: boolean): string | undefined {

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -294,3 +294,20 @@ describe('DataSource.applyTemplateVariables interpolates event query Options', (
     expect(eventQuery.Options?.Aggregation?.Period).toBe('1m')
   })
 })
+
+describe('DataSource.applyTemplateVariables tolerates a missing AssetProperties', () => {
+  it('does not throw for an asset measurement query without AssetProperties', () => {
+    const ds = makeDataSource(makeTemplateSrv({}))
+    const target = {
+      refId: 'A',
+      queryType: 'AssetMeasurementQuery',
+      query: {
+        Assets: ['asset-uuid'],
+        // AssetProperties deliberately missing (old/hand-edited dashboard JSON)
+        Options: { GroupBy: [], Tags: {} },
+      },
+    } as unknown as Query
+
+    expect(() => ds.applyTemplateVariables(target, {})).not.toThrow()
+  })
+})

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -261,3 +261,36 @@ describe('DataSource.applyTemplateVariables', () => {
     })
   })
 })
+
+describe('DataSource.applyTemplateVariables interpolates event query Options', () => {
+  it('replaces variables in Tags, ValueFilters and Aggregation of an event query', () => {
+    const ds = makeDataSource(makeTemplateSrv({ status: 'Good', threshold: '42', period: '1m' }))
+    const target: Query = {
+      refId: 'A',
+      queryType: 'EventQuery',
+      query: makeEventQuery({
+        QueryAssetProperties: true,
+        Options: {
+          Tags: { status: '$status' },
+          ValueFilters: [{ Value: '$threshold', Operator: '>', Condition: 'AND' }],
+          Aggregation: { Name: 'mean', Period: '$period' },
+          GroupBy: [],
+          IncludeLastKnownPoint: false,
+          FillInitialEmptyValues: false,
+          UseEngineeringSpecs: false,
+          DisplayDatabaseName: false,
+          DisplayDescription: false,
+          MetadataAsLabels: false,
+          TruncateInterval: false,
+        },
+      } as Partial<EventQuery>),
+    } as Query
+
+    const result = ds.applyTemplateVariables(target, {})
+    const eventQuery = result.query as EventQuery
+
+    expect(eventQuery.Options?.Tags).toEqual({ status: 'Good' })
+    expect(eventQuery.Options?.ValueFilters?.[0].Value).toBe('42')
+    expect(eventQuery.Options?.Aggregation?.Period).toBe('1m')
+  })
+})

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -311,3 +311,11 @@ describe('DataSource.applyTemplateVariables tolerates a missing AssetProperties'
     expect(() => ds.applyTemplateVariables(target, {})).not.toThrow()
   })
 })
+
+describe('DataSource.filterQuery rejects targets without a queryType', () => {
+  it('filters out a target that has no queryType', () => {
+    const ds = makeDataSource(makeTemplateSrv({}))
+    const target = { refId: 'A', query: makeEventQuery() } as unknown as Query
+    expect(ds.filterQuery(target)).toBe(false)
+  })
+})

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -319,3 +319,18 @@ describe('DataSource.filterQuery rejects targets without a queryType', () => {
     expect(ds.filterQuery(target)).toBe(false)
   })
 })
+
+describe('DataSource.applyTemplateVariables seriesLimit falls back on an empty variable', () => {
+  it('uses the default seriesLimit when the variable resolves to ""', () => {
+    const ds = makeDataSource(makeTemplateSrv({ lim: '' }))
+    const target = {
+      refId: 'A',
+      queryType: 'EventQuery',
+      seriesLimit: '$lim',
+      query: makeEventQuery(),
+    } as unknown as Query
+
+    const result = ds.applyTemplateVariables(target, {})
+    expect(result.seriesLimit).toBe(50)
+  })
+})

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -151,6 +151,10 @@ export class DataSource extends DataSourceWithBackend<Query, HistorianDataSource
     eventQuery.PropertyFilter = this.replaceEventPropertyFilter(eventQuery.PropertyFilter, scopedVars)
     eventQuery.Limit = this.templatedNumber(eventQuery.Limit, 500, scopedVars)
 
+    if (eventQuery.Options) {
+      eventQuery.Options = this.templateReplaceQueryOptions(eventQuery.Options, scopedVars)
+    }
+
     if (eventQuery.QueryAssetProperties) {
       eventQuery.OverrideAssets = eventQuery.OverrideAssets?.filter((e) => e !== '').flatMap((e) =>
         this.multiSelectReplace(e, scopedVars)

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -111,7 +111,7 @@ export class DataSource extends DataSourceWithBackend<Query, HistorianDataSource
       case 'AssetMeasurementQuery': {
         const q = JSON.parse(JSON.stringify(query)) as AssetMeasurementQuery
         q.Assets = q.Assets?.flatMap((e) => this.multiSelectReplace(e, scopedVars))
-        q.AssetProperties = q.AssetProperties.flatMap((e) => this.multiSelectReplace(e, scopedVars))
+        q.AssetProperties = q.AssetProperties?.flatMap((e) => this.multiSelectReplace(e, scopedVars))
         q.Options = this.templateReplaceQueryOptions(q.Options, scopedVars)
         q.Options.ValueFilters = q.Options.ValueFilters?.filter((e) => e.Value !== 'enter a value')
         return q

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -191,7 +191,7 @@ export class DataSource extends DataSourceWithBackend<Query, HistorianDataSource
   }
 
   filterQuery(target: Query): boolean {
-    return target.query !== undefined
+    return target.query !== undefined && target.queryType !== undefined
   }
 
   replaceEventPropertyFilter(

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -524,7 +524,14 @@ export class DataSource extends DataSourceWithBackend<Query, HistorianDataSource
 
   // Replace template variables in the provided value and convert it to a number, of valid
   templatedNumber(raw: number | string | undefined, defaultValue: number, scopedVars?: ScopedVars): number {
-    const replaced = typeof raw === 'string' ? Number(this.templateSrv.replace(raw, scopedVars)) : raw
-    return typeof replaced === 'number' && !Number.isNaN(replaced) ? replaced : defaultValue
+    if (typeof raw === 'string') {
+      const resolved = this.templateSrv.replace(raw, scopedVars)
+      if (resolved.trim() === '') {
+        return defaultValue
+      }
+      const parsed = Number(resolved)
+      return Number.isFinite(parsed) ? parsed : defaultValue
+    }
+    return typeof raw === 'number' && !Number.isNaN(raw) ? raw : defaultValue
   }
 }

--- a/src/util/migration.test.ts
+++ b/src/util/migration.test.ts
@@ -1,0 +1,32 @@
+import { migrateEventTypePropertiesValuesFilter } from './migration'
+import { EventQuery, OldEventTypePropertiesValuesFilter } from '../types'
+
+function makeEventQuery(overrides?: Partial<EventQuery>): EventQuery {
+  return {
+    Type: 'simple',
+    Assets: [],
+    EventTypes: [],
+    Statuses: [],
+    Properties: [],
+    PropertyFilter: [],
+    QueryAssetProperties: false,
+    ...overrides,
+  } as EventQuery
+}
+
+// migrateEventTypePropertiesValuesFilter must not push the migrated UUID into
+// the input's nested Properties array (a shared reference through the shallow
+// spread), which would mutate the caller's saved filter.
+describe('filter migration does not mutate its input', () => {
+  it('leaves the original EventFilter.Properties untouched', () => {
+    const old = {
+      EventTypePropertyUUID: 'new-uuid',
+      EventFilter: makeEventQuery({ Properties: ['existing-uuid'] }),
+    } as unknown as OldEventTypePropertiesValuesFilter
+
+    const migrated = migrateEventTypePropertiesValuesFilter(old)
+
+    expect(migrated?.EventFilter.Properties).toEqual(['existing-uuid', 'new-uuid'])
+    expect(old.EventFilter.Properties).toEqual(['existing-uuid'])
+  })
+})

--- a/src/util/migration.ts
+++ b/src/util/migration.ts
@@ -35,7 +35,7 @@ export function migrateEventTypePropertiesValuesFilter(
     ...rest,
     EventFilter: {
       ...rest.EventFilter,
-      Properties: rest.EventFilter?.Properties ?? [],
+      Properties: [...(rest.EventFilter?.Properties ?? [])],
     },
   }
 

--- a/src/util/semver.test.ts
+++ b/src/util/semver.test.ts
@@ -83,3 +83,9 @@ describe('isFeatureEnabled', () => {
     expect(isFeatureEnabled('7.3.0-alpha', '7.3.0')).toBe(false)
   })
 })
+
+describe('isFeatureEnabled fails closed on unknown versions', () => {
+  it('does not enable version-gated features for an empty version', () => {
+    expect(isFeatureEnabled('', '99.0.0')).toBe(false)
+  })
+})

--- a/src/util/semver.test.ts
+++ b/src/util/semver.test.ts
@@ -89,3 +89,10 @@ describe('isFeatureEnabled fails closed on unknown versions', () => {
     expect(isFeatureEnabled('', '99.0.0')).toBe(false)
   })
 })
+
+describe('semverCompare pre-release precedence', () => {
+  it('orders 1.0.0-alpha before 1.0.0-alpha.1', () => {
+    expect(semverCompare('1.0.0-alpha', '1.0.0-alpha.1')).toBeLessThan(0)
+    expect(semverCompare('1.0.0-alpha.1', '1.0.0-alpha')).toBeGreaterThan(0)
+  })
+})

--- a/src/util/semver.ts
+++ b/src/util/semver.ts
@@ -62,9 +62,12 @@ function comparePreRelease(a: string, b: string): number {
   const aParts = a.split('.')
   const bParts = b.split('.')
 
-  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-    const aPart = aParts[i] || ''
-    const bPart = bParts[i] || ''
+  // Only compare the identifiers the two versions share; padding the shorter
+  // list would invert precedence.
+  const shared = Math.min(aParts.length, bParts.length)
+  for (let i = 0; i < shared; i++) {
+    const aPart = aParts[i]
+    const bPart = bParts[i]
 
     // Compare numeric parts
     const aIsNum = /^\d+$/.test(aPart)
@@ -87,7 +90,9 @@ function comparePreRelease(a: string, b: string): number {
     }
   }
 
-  return 0
+  // All shared identifiers are equal: the larger set has higher precedence
+  // (SemVer item 11.4.4), so the shorter pre-release is lower.
+  return aParts.length - bParts.length
 }
 
 // Helper function to compare two semantic version strings

--- a/src/util/semver.ts
+++ b/src/util/semver.ts
@@ -132,8 +132,15 @@ export function semverCompare(a: string, b: string): number {
 
 // Helper function to check if a version is greater than or equal to a target version, excluding pre-releases by default
 export function isFeatureEnabled(version: string, targetVersion: string, includePreReleases = false): boolean {
+  const versionSemVer = parseSemVer(version)
+
+  // Fail closed for empty or unparseable versions (for example when the historian
+  // info fetch failed), except the documented 'debug' build marker which stays newest.
+  if (versionSemVer.isDebug && version !== 'debug') {
+    return false
+  }
+
   if (includePreReleases) {
-    let versionSemVer = parseSemVer(version)
     versionSemVer.preRelease = undefined
     version = toStringSemVer(versionSemVer)
   }

--- a/src/variable_support.test.ts
+++ b/src/variable_support.test.ts
@@ -48,3 +48,21 @@ describe('variable query without a filter returns empty data', () => {
     expect(() => vs.query(request)).not.toThrow()
   })
 })
+
+// A pre-v2.2.0 "Event property values" variable (filter with
+// EventTypePropertyUUID, no PropertyFilter) is migrated to an EventFilter
+// without PropertyFilter; reading `.PropertyFilter.length` behind an optional
+// chain that stops at EventFilter must not throw a TypeError.
+describe('PropertyValuesQuery works for migrated pre-v2.2.0 filters', () => {
+  it('does not throw when the migrated filter has no PropertyFilter', () => {
+    const vs = new VariableSupport(makeDataAPIStub({}))
+    const request = makeVariableRequest({
+      refId: 'A',
+      type: VariableQueryType.PropertyValuesQuery,
+      valid: true,
+      filter: { EventTypePropertyUUID: 'prop-uuid' },
+    })
+
+    expect(() => vs.query(request)).not.toThrow()
+  })
+})

--- a/src/variable_support.test.ts
+++ b/src/variable_support.test.ts
@@ -103,3 +103,14 @@ describe('PropertyValuesQuery interpolates EventFilter.Statuses', () => {
     expect(filter?.EventFilter?.Statuses).toEqual(['Good'])
   })
 })
+
+// VariableSupport.query must have a default branch: an unknown saved variable
+// type should return an observable instead of undefined, so Grafana shows a
+// clean error rather than crashing on `.subscribe` of undefined.
+describe('unknown variable query type', () => {
+  it('returns an observable instead of undefined', () => {
+    const vs = new VariableSupport(makeDataAPIStub({}))
+    const request = makeVariableRequest({ refId: 'A', type: 'bogus', valid: true })
+    expect(vs.query(request)).toBeDefined()
+  })
+})

--- a/src/variable_support.test.ts
+++ b/src/variable_support.test.ts
@@ -1,0 +1,50 @@
+import { dateTime } from '@grafana/data'
+
+import { VariableSupport, DataAPI } from './variable_support'
+import { VariableQueryType } from './types'
+
+// Minimal DataAPI stub that captures the filter passed to the distinct
+// property-value lookup and resolves $status to "Good".
+function makeDataAPIStub(captured: { filter?: unknown }): DataAPI {
+  return {
+    getMeasurements: jest.fn().mockResolvedValue([]),
+    getCollectors: jest.fn().mockResolvedValue([]),
+    getTimeseriesDatabases: jest.fn().mockResolvedValue([]),
+    getAssets: jest.fn().mockResolvedValue([]),
+    getAssetProperties: jest.fn().mockResolvedValue([]),
+    getEventTypes: jest.fn().mockResolvedValue([]),
+    getEventTypeProperties: jest.fn().mockResolvedValue([]),
+    getEventConfigurations: jest.fn().mockResolvedValue([]),
+    getDistinctEventPropertyValues: jest.fn().mockImplementation((filter) => {
+      captured.filter = filter
+      return Promise.resolve([])
+    }),
+    multiSelectReplace: (value: string | undefined) => [value === '$status' ? 'Good' : value ?? ''],
+    replace: (value: string | undefined) => (value === '$status' ? 'Good' : value ?? ''),
+  }
+}
+
+function makeVariableRequest(target: Record<string, unknown>) {
+  return {
+    targets: [target],
+    scopedVars: {},
+    range: { from: dateTime('2026-01-01T00:00:00Z'), to: dateTime('2026-01-02T00:00:00Z') },
+  } as never
+}
+
+// Every variable query branch does JSON.parse(JSON.stringify(target.filter));
+// with filter undefined this is JSON.parse(undefined) -> SyntaxError. Deep-clone
+// only when a filter exists so a filter-less variable query returns empty data.
+describe('variable query without a filter returns empty data', () => {
+  it('does not throw for a filter-less asset variable query', () => {
+    const vs = new VariableSupport(makeDataAPIStub({}))
+    const request = makeVariableRequest({
+      refId: 'A',
+      type: VariableQueryType.AssetQuery,
+      valid: true,
+      // filter deliberately missing (old/provisioned variable)
+    })
+
+    expect(() => vs.query(request)).not.toThrow()
+  })
+})

--- a/src/variable_support.test.ts
+++ b/src/variable_support.test.ts
@@ -1,7 +1,7 @@
 import { dateTime } from '@grafana/data'
 
 import { VariableSupport, DataAPI } from './variable_support'
-import { VariableQueryType } from './types'
+import { EventQuery, VariableQueryType } from './types'
 
 // Minimal DataAPI stub that captures the filter passed to the distinct
 // property-value lookup and resolves $status to "Good".
@@ -30,6 +30,19 @@ function makeVariableRequest(target: Record<string, unknown>) {
     scopedVars: {},
     range: { from: dateTime('2026-01-01T00:00:00Z'), to: dateTime('2026-01-02T00:00:00Z') },
   } as never
+}
+
+function makeEventQuery(overrides?: Partial<EventQuery>): EventQuery {
+  return {
+    Type: 'simple',
+    Assets: [],
+    EventTypes: [],
+    Statuses: [],
+    Properties: [],
+    PropertyFilter: [],
+    QueryAssetProperties: false,
+    ...overrides,
+  } as EventQuery
 }
 
 // Every variable query branch does JSON.parse(JSON.stringify(target.filter));
@@ -64,5 +77,29 @@ describe('PropertyValuesQuery works for migrated pre-v2.2.0 filters', () => {
     })
 
     expect(() => vs.query(request)).not.toThrow()
+  })
+})
+
+// The PropertyValuesQuery variable path interpolates Assets, EventTypes,
+// Properties and PropertyFilter but must also interpolate EventFilter.Statuses,
+// otherwise a $status variable is sent literally and the variable returns no
+// values.
+describe('PropertyValuesQuery interpolates EventFilter.Statuses', () => {
+  it('resolves template variables in Statuses', () => {
+    const captured: { filter?: unknown } = {}
+    const vs = new VariableSupport(makeDataAPIStub(captured))
+    const request = makeVariableRequest({
+      refId: 'A',
+      type: VariableQueryType.PropertyValuesQuery,
+      valid: true,
+      filter: {
+        EventFilter: makeEventQuery({ Statuses: ['$status'], Properties: ['prop-uuid'] }),
+      },
+    })
+
+    vs.query(request)
+
+    const filter = captured.filter as { EventFilter?: EventQuery } | undefined
+    expect(filter?.EventFilter?.Statuses).toEqual(['Good'])
   })
 })

--- a/src/variable_support.ts
+++ b/src/variable_support.ts
@@ -43,6 +43,12 @@ export interface DataAPI {
   replace(value: string | undefined, scopedVars: ScopedVars): string
 }
 
+// Deep-clones a filter, returning undefined when there is nothing to clone so
+// the `if (!filter)` guards below stay reachable instead of parsing undefined.
+function cloneFilter<T>(filter: T | undefined): T | undefined {
+  return filter === undefined ? undefined : (JSON.parse(JSON.stringify(filter)) as T)
+}
+
 export class VariableSupport extends CustomVariableSupport<DataSource> {
   constructor(private readonly dataAPI: DataAPI) {
     super()
@@ -61,13 +67,13 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
 
     switch (queryType) {
       case VariableQueryType.MeasurementQuery: {
-        const filter = {
-          ...(JSON.parse(JSON.stringify(request.targets[0].filter)) as MeasurementFilter | undefined),
-          ScopedVars: request.scopedVars,
-        }
-
-        if (!filter) {
+        const parsed = cloneFilter(request.targets[0].filter) as MeasurementFilter | undefined
+        if (!parsed) {
           return of({ data: [] })
+        }
+        const filter = {
+          ...parsed,
+          ScopedVars: request.scopedVars,
         }
 
         let pagination: Pagination = {
@@ -106,14 +112,14 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
         )
       }
       case VariableQueryType.AssetQuery: {
-        const filter = {
-          ...(JSON.parse(JSON.stringify(request.targets[0].filter)) as AssetFilter | undefined),
-          ScopedVars: request.scopedVars,
-        }
-
         // Don't allow empty filter to not query too much data
-        if (!filter) {
+        const parsed = cloneFilter(request.targets[0].filter) as AssetFilter | undefined
+        if (!parsed) {
           return of({ data: [] })
+        }
+        const filter = {
+          ...parsed,
+          ScopedVars: request.scopedVars,
         }
         const useAssetPath = filter.UseAssetPath ?? false
         return from(this.dataAPI.getAssets(filter)).pipe(
@@ -128,12 +134,13 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
         )
       }
       case VariableQueryType.EventTypeQuery: {
-        const filter = {
-          ...(JSON.parse(JSON.stringify(request.targets[0].filter)) as EventTypeFilter | undefined),
-          ScopedVars: request.scopedVars,
-        }
-        if (!filter) {
+        const parsed = cloneFilter(request.targets[0].filter) as EventTypeFilter | undefined
+        if (!parsed) {
           return of({ data: [] })
+        }
+        const filter = {
+          ...parsed,
+          ScopedVars: request.scopedVars,
         }
         return from(this.dataAPI.getEventTypes(filter)).pipe(
           map((values) => {
@@ -142,12 +149,13 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
         )
       }
       case VariableQueryType.DatabaseQuery: {
-        const filter = {
-          ...(JSON.parse(JSON.stringify(request.targets[0].filter)) as TimeseriesDatabaseFilter | undefined),
-          ScopedVars: request.scopedVars,
-        }
-        if (!filter) {
+        const parsed = cloneFilter(request.targets[0].filter) as TimeseriesDatabaseFilter | undefined
+        if (!parsed) {
           return of({ data: [] })
+        }
+        const filter = {
+          ...parsed,
+          ScopedVars: request.scopedVars,
         }
         return from(this.dataAPI.getTimeseriesDatabases(filter)).pipe(
           map((values) => {
@@ -156,12 +164,13 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
         )
       }
       case VariableQueryType.EventTypePropertyQuery: {
-        const filter = {
-          ...(JSON.parse(JSON.stringify(request.targets[0].filter)) as EventTypePropertiesFilter | undefined),
-          ScopedVars: request.scopedVars,
-        }
-        if (!filter) {
+        const parsed = cloneFilter(request.targets[0].filter) as EventTypePropertiesFilter | undefined
+        if (!parsed) {
           return of({ data: [] })
+        }
+        const filter = {
+          ...parsed,
+          ScopedVars: request.scopedVars,
         }
         return forkJoin({
           eventTypes: this.dataAPI.getEventTypes(),
@@ -182,12 +191,13 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
         )
       }
       case VariableQueryType.AssetPropertyQuery: {
-        const filter = {
-          ...(JSON.parse(JSON.stringify(request.targets[0].filter)) as AssetPropertyFilter | undefined),
-          ScopedVars: request.scopedVars,
-        }
-        if (!filter) {
+        const parsed = cloneFilter(request.targets[0].filter) as AssetPropertyFilter | undefined
+        if (!parsed) {
           return of({ data: [] })
+        }
+        const filter = {
+          ...parsed,
+          ScopedVars: request.scopedVars,
         }
         if (filter.AssetUUIDs) {
           filter.AssetUUIDs = filter.AssetUUIDs.flatMap((e) => this.dataAPI.multiSelectReplace(e, request.scopedVars))
@@ -199,7 +209,7 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
         )
       }
       case VariableQueryType.PropertyValuesQuery: {
-        const rawFilter = JSON.parse(JSON.stringify(request.targets[0].filter)) as
+        const rawFilter = cloneFilter(request.targets[0].filter) as
           | EventTypePropertiesValuesFilter
           | OldEventTypePropertiesValuesFilter
           | undefined

--- a/src/variable_support.ts
+++ b/src/variable_support.ts
@@ -234,6 +234,11 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
             this.dataAPI.multiSelectReplace(e, request.scopedVars)
           )
         }
+        if (filter.EventFilter?.Statuses) {
+          filter.EventFilter.Statuses = filter.EventFilter.Statuses.flatMap((e) =>
+            this.dataAPI.multiSelectReplace(e, request.scopedVars)
+          )
+        }
         if (filter.EventFilter?.Properties) {
           filter.EventFilter.Properties = filter.EventFilter.Properties.flatMap((e) =>
             this.dataAPI.multiSelectReplace(e, request.scopedVars)

--- a/src/variable_support.ts
+++ b/src/variable_support.ts
@@ -239,7 +239,7 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
             this.dataAPI.multiSelectReplace(e, request.scopedVars)
           )
         }
-        if ((filter.EventFilter?.PropertyFilter.length ?? 0) > 0) {
+        if ((filter.EventFilter?.PropertyFilter?.length ?? 0) > 0) {
           filter.EventFilter!.PropertyFilter = filter.EventFilter!.PropertyFilter?.map((e) => {
             e.Property = this.dataAPI.replace(e.Property, request.scopedVars)
             if (e.Operator === 'IN' || e.Operator === 'NOT IN') {

--- a/src/variable_support.ts
+++ b/src/variable_support.ts
@@ -285,6 +285,9 @@ export class VariableSupport extends CustomVariableSupport<DataSource> {
           })
         )
       }
+      default: {
+        return of({ data: [] })
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Executable confirmation of the 2026-07-03 bug audit, plus fixes for every finding the tests cover. Each finding has a regression test that asserts the correct behavior; all 31 test-covered findings are fixed. **Full CI green: `go vet`, `go test -race ./...`, typecheck, eslint, and 188 Jest tests all pass.**

## Commit structure

The branch is organized so **every commit is one bug and its test** (fix + regression test together). Two coupled pairs share a commit because they share a single code change: B2+B4a (the `deleteFirstRow` signature/guard) and B4b+B4c (two guards in `fillInitialEmptyIntervals`). 29 commits total.

Each test lives in the conventionally-named test file for the code under test (`query_handler_test.go`, `dataframe_test.go`, `events_test.go`, `resource_handler_test.go`, `historian_test.go`, `util_test.go`, `api_test.go`, `periodic_property_values_test.go`, `semver_test.go`; `datasource.test.ts`, `variable_support.test.ts`, `util/semver.test.ts`, `util/migration.test.ts`, `components/TagsSection/util.test.ts`), reusing existing helpers where present. History was rewritten from the 8db9498 base for this structure; production code is byte-identical to the prior green tip, only the tests were reorganized into their proper files.

The finding IDs below map to the Notion report ("Bug audit: factry-historian-datasource (2026-07-03)"). They are used only in this description; the code and commit messages carry no audit IDs (test names describe the behavior under test).

### Backend (Go) — all 19 fixed
- **B1** (HIGH) Asset queries without a property filter returned every series twice; selection now deduplicates by property UUID.
- **B2** (HIGH) `deleteFirstRow` dropped the first real sample of series with no last-known point; only frames that received one are trimmed (also fixes **B4a**).
- **B3** (MED-HIGH) `event-property-values` without a `Properties` param panicked and killed the plugin process; now returns an error.
- **B4b/B4c** (MED) `fillInitialEmptyIntervals` panicked on zero-row frames and nil `Aggregation`.
- **B5** (MED) Raw queries divided by zero when `intervalMs` was omitted.
- **B6** (MED) Events with a `ParentUUID` but no embedded parent panicked.
- **B7** (MED) `Parent_StopTime` was written to the wrong label map (always empty).
- **B8** (MED) Event table rows misaligned when GroupBy status yielded multiple frames per property.
- **B9** (MED) `seriesLimit` 0 truncated results; a non-positive limit now means unlimited.
- **B10** (MED) Periodic property payloads with mismatched `t`/`v` lengths panicked.
- **B11** (MED) `Timeout`/`QueryTimeout`/`tlsSkipVerify` are now wired into the HTTP client (`NewAPIWithToken` kept as a wrapper).
- **B12** (MED) Percent-escaped path segments are preserved behind a URL path prefix.
- **B13** (LOW) SemVer pre-release precedence corrected (and the test row that asserted the inversion flipped).
- **B15** (LOW) `sortByStatus` no longer panics on nil Meta and uses a valid stable ordering.
- **B16** (LOW) Unknown event property datatypes fall back to nullable string columns.
- **B18** (LOW) Resource responses set `Content-Type: application/json` before the body write.
- **B19** (LOW) `mergeFrames` keeps the fresh result frame on a field-count mismatch.

### Frontend (TypeScript) — all 12 test-covered findings fixed
- **F1** (HIGH) Event query `Options` (Tags, ValueFilters, Aggregation) are now template-interpolated.
- **F2** (HIGH) `PropertyValuesQuery` variable no longer crashes on migrated pre-v2.2.0 filters (optional chain).
- **F5** (MED) Variable queries no longer throw on a missing filter; the empty-filter guard is now reachable.
- **F12** (MED) Regex filter values use the supported `~` operator instead of the unsupported `=~`.
- **F13** (MED) The variable path now interpolates `EventFilter.Statuses`.
- **F15** (MED) `applyTemplateVariables` no longer throws when `AssetProperties` is missing.
- **F16** (MED) Unknown/empty historian versions now fail closed for feature gating (literal `debug` still enables features).
- **F18** (LOW) SemVer pre-release precedence corrected (mirrors B13).
- **F19** (LOW) `filterQuery` rejects targets without a `queryType`.
- **F20** (LOW) `templatedNumber` falls back to the default when a variable resolves to an empty string.
- **F24** (LOW) The filter migration no longer mutates the caller's nested `Properties` array.
- **F26** (LOW) `VariableSupport.query` returns an empty observable for unknown query types instead of `undefined`.

### Policy choices (flag if you disagree)
- Non-positive `seriesLimit` = unlimited (restores pre-limit behavior for old saved queries).
- `QueryTimeout` maps to the HTTP request timeout, `Timeout` to the dial timeout.
- Empty/unparseable historian version fails closed for feature gates; the literal `debug` marker stays "newest".

### Not addressed (untested hygiene findings, tracked in Notion)
Backend B14, B17, B20-B24 and frontend F3, F4, F6-F11, F14, F17, F21-F23, F25, F27-F33. Most need component-level (RTL) harnesses or are latent/cosmetic; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)