### PR TITLE
test(e2e): expand suite across all editors and add coverage reporting

### DIFF
--- a/.github/actions/grafana/action.yml
+++ b/.github/actions/grafana/action.yml
@@ -77,12 +77,12 @@ runs:
     - name: Generate artifact attestation
       if: ${{ inputs.attestation == 'true' }}
       id: attestation
-      uses: actions/attest-build-provenance@v2
+      uses: actions/attest-build-provenance@v3
       with:
         subject-path: ${{ steps.package-plugin.outputs.archive }}
 
     - name: Create Github release
-      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+      uses: softprops/action-gh-release@fe965f7af51af5f2602596916f38a38df2e33de0 # v3.0.2
       with:
         draft: true
         generate_release_notes: true

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -14,6 +14,10 @@ runs:
       uses: actions/setup-node@v5
       with:
         node-version: 24
+        # setup-node v5 caches automatically when package.json has a
+        # packageManager field, which needs pnpm on PATH before pnpm is
+        # installed below. The explicit store cache further down does this job.
+        package-manager-cache: false
 
     # No version pin here on purpose: with none given, pnpm/action-setup reads
     # the packageManager field in package.json, so the version is set in one

--- a/.github/actions/pnpm/action.yml
+++ b/.github/actions/pnpm/action.yml
@@ -7,18 +7,18 @@ runs:
     # This runs after the calling job's own checkout, so without
     # persist-credentials: false it would put GITHUB_TOKEN back into
     # .git/config and undo the setting there.
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: 24
 
     # No version pin here on purpose: with none given, pnpm/action-setup reads
     # the packageManager field in package.json, so the version is set in one
     # place. Pinning both errors out whenever the two drift apart.
-    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+    - uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
       name: Install pnpm
       with:
         run_install: false
@@ -27,7 +27,7 @@ runs:
       shell: bash
       run: |
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       name: Setup pnpm cache
       with:
         path: ${{ env.STORE_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,10 +229,42 @@ jobs:
           path: dist
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
 
+      # Guard against a nested or incomplete artifact layout: Grafana mounts
+      # ./dist as the plugin directory, so these files must sit at its root.
+      - name: Check plugin artifact layout
+        if: needs.build.outputs.has-backend == 'true'
+        run: |
+          test -f dist/plugin.json || { echo "dist/plugin.json missing"; ls -laR dist | head -50; exit 1; }
+          test -f dist/gpx_factry-historian-datasource_linux_amd64 || { echo "backend binary missing"; ls -la dist; exit 1; }
+          test ! -d dist/dist || { echo "artifact contains a nested dist/ directory"; ls -la dist; exit 1; }
+
+      - name: Setup Go environment
+        if: needs.build.outputs.has-backend == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      # Replace the release binary with a coverage-instrumented build so the
+      # e2e run measures backend coverage (GOCOVERDIR is wired up in
+      # docker-compose.e2e.yaml). The signature manifest no longer matches the
+      # modified binary, so drop it; the e2e Grafana allows unsigned plugins.
+      - name: Build coverage-instrumented backend
+        if: needs.build.outputs.has-backend == 'true'
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -cover -covermode=atomic -coverpkg=./pkg/... -o dist/gpx_factry-historian-datasource_linux_amd64 ./pkg
+          rm -f dist/MANIFEST.txt
+
       - name: Execute permissions on binary
         if: needs.build.outputs.has-backend == 'true'
         run: |
           chmod +x ./dist/gpx_factry-historian-datasource_linux_amd64
+
+      # The grafana container user must be able to write coverage counters into
+      # the bind-mounted directory.
+      - name: Prepare coverage directories
+        run: |
+          mkdir -p coverage/e2e-backend-raw
+          chmod 777 coverage/e2e-backend-raw
 
       - name: Start Grafana and mock Historian
         run: |
@@ -250,12 +282,26 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install chromium --with-deps
 
+      # Fail fast with a clear signal when the plugin did not load or the
+      # datasource cannot reach the mock, instead of 18 opaque test failures.
+      - name: Verify plugin and datasource health
+        run: |
+          # The e2e Grafana runs with anonymous admin access (basic auth is disabled).
+          echo "--- plugin settings ---"
+          curl -sf http://localhost:3001/api/plugins/factry-historian-datasource/settings
+          echo
+          echo "--- datasource health ---"
+          curl -s http://localhost:3001/api/datasources/uid/factry-historian-e2e/health
+          echo
+
       - name: Run Playwright tests
         id: run-tests
-        run: pnpm run e2e
+        run: pnpm run e2e:coverage
 
+      # Also runs when the job was cancelled by a timeout or an earlier step
+      # failed: 'cancelled' and 'skipped' are != 'success' too.
       - name: Docker logs
-        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.run-tests.outcome != 'success' }}
         run: |
           docker logs factry-historian-datasource >& grafana-server.log
           # The mock logs every request it served, which shows at a glance
@@ -263,11 +309,29 @@ jobs:
           docker logs factry-historian-mock >& mockhistorian.log
 
       - name: Stop grafana docker
+        if: ${{ always() }}
         run: docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml down
+
+      # Renders the frontend + backend e2e coverage summary (also into the job
+      # summary) and produces the HTML reports uploaded below.
+      - name: E2E coverage report
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' }}
+        run: bash scripts/e2e-coverage-report.sh
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v4
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' }}
+        with:
+          name: e2e-coverage-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
+          path: |
+            coverage/e2e-frontend
+            coverage/e2e-backend.cov
+            coverage/e2e-backend.html
+          retention-days: 5
 
       - name: Upload server log
         uses: actions/upload-artifact@v4
-        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.run-tests.outcome != 'success' }}
         with:
           name: ${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}-server-log
           path: |
@@ -279,8 +343,12 @@ jobs:
       # Beware not to expose sensitive information.
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.run-tests.outcome != 'success' }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
+          # test-results/ carries the traces and error-context snapshots, which
+          # are what actually pin down a failure.
+          path: |
+            playwright-report/
+            test-results/
           retention-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,22 @@ jobs:
       - name: Verify plugin and datasource health
         run: |
           # The e2e Grafana runs with anonymous admin access (basic auth is disabled).
+          # Provisioning runs after the HTTP server binds, so Grafana can pass the
+          # wait above and then exit. Retry briefly and name the problem if it
+          # stays down, instead of failing on a bare curl exit code.
+          healthy=false
+          for attempt in $(seq 10); do
+            if curl -sf -o /dev/null http://localhost:3001/api/plugins/factry-historian-datasource/settings; then
+              healthy=true
+              break
+            fi
+            sleep 3
+          done
+          if [ "$healthy" != true ]; then
+            echo "::error::Grafana stopped serving the plugin settings endpoint"
+            docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml ps
+            exit 1
+          fi
           echo "--- plugin settings ---"
           curl -sf http://localhost:3001/api/plugins/factry-historian-datasource/settings
           echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       # persist-credentials: false everywhere in this repo. No workflow pushes
       # over git, so nothing needs GITHUB_TOKEN left behind in .git/config where
       # any later step or third-party action could read it.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: ./.github/actions/pnpm
@@ -62,7 +62,7 @@ jobs:
 
       - name: Update coverage badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.COVERAGE_GIST_ID != ''
-        uses: Schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483
+        uses: Schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
         with:
           auth: ${{ secrets.GIST_SECRET }}
           gistID: ${{ vars.COVERAGE_GIST_ID }}
@@ -85,9 +85,12 @@ jobs:
 
       - name: Setup Go environment
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          # setup-go v6 keys the module cache on go.mod by default; go.sum keeps
+          # the key tied to the resolved dependency set, as v5 did.
+          cache-dependency-path: go.sum
 
       - name: golangci-lint
         if: steps.check-for-backend.outputs.has-backend == 'true'
@@ -111,14 +114,14 @@ jobs:
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3
+        uses: magefile/mage-action@a662bd8c29d8106879588cfff83b2faf6e6f59db # v4.0.0
         with:
           version: latest
           args: coverage
 
       - name: Install Mage
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3
+        uses: magefile/mage-action@a662bd8c29d8106879588cfff83b2faf6e6f59db # v4.0.0
         with:
           version: latest
           install-only: true
@@ -167,7 +170,7 @@ jobs:
           zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
 
       - name: Archive Build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.metadata.outputs.plugin-id }}-${{ steps.metadata.outputs.plugin-version }}
           path: ${{ steps.metadata.outputs.plugin-id }}
@@ -183,7 +186,7 @@ jobs:
       matrix: ${{ steps.resolve-versions.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Resolve Grafana E2E versions
@@ -215,7 +218,7 @@ jobs:
     steps:
       # Full checkout: docker-compose.e2e.yaml builds the mock Historian from
       # source (needs go.mod, pkg/, tests/), so a sparse checkout is not enough.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -224,7 +227,7 @@ jobs:
 
       - name: Download plugin
         if: needs.build.outputs.has-backend == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
@@ -240,9 +243,12 @@ jobs:
 
       - name: Setup Go environment
         if: needs.build.outputs.has-backend == 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
+          # setup-go v6 keys the module cache on go.mod by default; go.sum keeps
+          # the key tied to the resolved dependency set, as v5 did.
+          cache-dependency-path: go.sum
 
       # Replace the release binary with a coverage-instrumented build so the
       # e2e run measures backend coverage (GOCOVERDIR is wired up in
@@ -319,7 +325,7 @@ jobs:
         run: bash scripts/e2e-coverage-report.sh
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ always() && steps.run-tests.outcome != 'skipped' }}
         with:
           name: e2e-coverage-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
@@ -330,7 +336,7 @@ jobs:
           retention-days: 5
 
       - name: Upload server log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ always() && steps.run-tests.outcome != 'success' }}
         with:
           name: ${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}-server-log
@@ -342,7 +348,7 @@ jobs:
       # If your repository is public, uploading the Playwright report will make it public on the Internet.
       # Beware not to expose sensitive information.
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ always() && steps.run-tests.outcome != 'success' }}
         with:
           name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}

--- a/.github/workflows/is-compatible.yml
+++ b/.github/workflows/is-compatible.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: ./.github/actions/pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       attestations: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - uses: ./.github/actions/pnpm
@@ -52,7 +52,7 @@ jobs:
       TAG: ${{ github.ref_name }}
       ARCHBEE_TOKEN: ${{ secrets.ARCHBEE_GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ pids
 lib-cov
 
 # Coverage directory used by tools like istanbul
-coverage
+/coverage/
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 dist/

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -19,5 +19,15 @@ services:
       # /etc/grafana/provisioning is ignored (docker-compose appends volume
       # lists, so we cannot replace the dev mount in place).
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning-e2e
+      # Backend e2e coverage: the plugin binary flushes Go coverage counters to
+      # GOCOVERDIR when built with `go build -cover` (see pkg/coverageflush.go).
+      # forward_host_env_vars takes PLUGIN IDs: Grafana >= 12.4 no longer
+      # passes host env vars to plugin subprocesses unless the plugin is
+      # listed. Both are no-ops for a regular (non -cover) binary.
+      GOCOVERDIR: /coverage
+      GF_PLUGINS_FORWARD_HOST_ENV_VARS: factry-historian-datasource
     volumes:
       - ./tests/provisioning:/etc/grafana/provisioning-e2e
+      # Host directory must be writable by the grafana user (CI pre-creates it
+      # with chmod 777); counter files land in coverage/e2e-backend-raw.
+      - ./coverage/e2e-backend-raw:/coverage

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -26,6 +26,15 @@ services:
       # listed. Both are no-ops for a regular (non -cover) binary.
       GOCOVERDIR: /coverage
       GF_PLUGINS_FORWARD_HOST_ENV_VARS: factry-historian-datasource
+      # Grafana >= 11.5 preinstalls a few first-party apps (explore traces,
+      # metrics drilldown, ...) from grafana.com in the background on startup.
+      # Those installs write to the same SQLite file as datasource
+      # provisioning, and provisioning losing that lock kills the server:
+      #   Datasource provisioning error: database is locked
+      # It exits after the health endpoint has already answered, so the leg
+      # fails later with a connection refused. None of those apps are used
+      # here, and skipping the downloads also cuts about a minute off startup.
+      GF_PLUGINS_PREINSTALL_DISABLED: 'true'
     volumes:
       - ./tests/provisioning:/etc/grafana/provisioning-e2e
       # Host directory must be writable by the grafana user (CI pre-creates it

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lint": "eslint --cache .",
     "lint:fix": "pnpm run lint -- --fix",
     "e2e": "playwright test",
+    "e2e:coverage": "E2E_COVERAGE=true playwright test",
     "server": "docker-compose up --build",
+    "server:e2e": "docker compose -f docker-compose.yaml -f docker-compose.e2e.yaml up --build",
     "sign": "pnpx @grafana/sign-plugin@latest"
   },
   "author": "Factry",
@@ -52,6 +54,7 @@
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "monocart-coverage-reports": "^2.12.12",
     "prettier": "^2.8.8",
     "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "1.97.3",

--- a/pkg/coverageflush.go
+++ b/pkg/coverageflush.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"runtime/coverage"
+	"time"
+)
+
+// startCoverageFlusher periodically writes coverage counter data to
+// GOCOVERDIR. It is a no-op unless the binary was built with `go build
+// -cover` AND GOCOVERDIR is set (the e2e suite does both; production builds
+// never set GOCOVERDIR). The periodic flush is needed because Grafana kills
+// the plugin subprocess on shutdown, so the usual write-at-exit never runs.
+func startCoverageFlusher() {
+	dir := os.Getenv("GOCOVERDIR")
+	if dir == "" {
+		return
+	}
+
+	go func() {
+		// WriteMetaDir/WriteCountersDir return an error when the binary is not
+		// built with -cover; ignoring it keeps this dormant in normal builds.
+		_ = coverage.WriteMetaDir(dir)
+		for range time.Tick(15 * time.Second) {
+			_ = coverage.WriteCountersDir(dir)
+		}
+	}()
+}

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -9,6 +9,7 @@ import (
 )
 
 func main() {
+	startCoverageFlusher()
 	if err := datasource.Manage("factry-historian-datasource", historianDataSource.NewDataSource, datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,10 @@ export default defineConfig<PluginOptions>({
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'html',
+  // V8 coverage collection roughly doubles page load time, which pushes a first
+  // panel render past the 5s default and makes the provisioned-dashboard specs
+  // flake. Panels are the slowest thing asserted on, so raise it suite-wide.
+  expect: { timeout: 15_000 },
   // Frontend coverage collection (no-ops unless E2E_COVERAGE=true).
   globalSetup: require.resolve('./tests/coverage/global-setup'),
   globalTeardown: require.resolve('./tests/coverage/global-teardown'),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,9 +12,12 @@ export default defineConfig<PluginOptions>({
   testMatch: ['**/*.spec.ts'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: 'html',
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'html',
+  // Frontend coverage collection (no-ops unless E2E_COVERAGE=true).
+  globalSetup: require.resolve('./tests/coverage/global-setup'),
+  globalTeardown: require.resolve('./tests/coverage/global-teardown'),
   use: {
     // This repo's docker-compose publishes Grafana on host port 3001 (-> 3000).
     baseURL: process.env.GRAFANA_URL ?? 'http://localhost:3001',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0(supports-color@8.1.1)
+      monocart-coverage-reports:
+        specifier: ^2.12.12
+        version: 2.12.12
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -1504,8 +1507,16 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
+
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
 
   acorn@8.15.0:
@@ -1824,6 +1835,10 @@ packages:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
 
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -1840,6 +1855,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  console-grid@2.2.4:
+    resolution: {integrity: sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg==}
 
   continuable-cache@0.3.1:
     resolution: {integrity: sha512-TF30kpKhTH8AGCG3dut0rdd/19B7Z+qCnrMoBLpyQu/2drZdNrrpcjPEoJeSVsQM+8KmWG5O56oPDjSSUsuTyA==}
@@ -2187,6 +2205,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  eight-colors@1.3.3:
+    resolution: {integrity: sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg==}
+
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
@@ -2483,6 +2504,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  foreground-child@4.0.3:
+    resolution: {integrity: sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==}
+    engines: {node: '>=16'}
 
   fork-ts-checker-webpack-plugin@8.0.0:
     resolution: {integrity: sha512-mX3qW3idpueT2klaQXBzrIM/pHw+T0B/V9KHEvNrqijTq9NFnMZU6oreVxDYcf33P8a5cW+67PjodNHthGnNVg==}
@@ -3230,6 +3255,9 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  lz-utils@2.1.1:
+    resolution: {integrity: sha512-d3Thjos0PSJQAoyMj6vipSSrtrRHS7DImqUNR8x9NW3+zQIftPIbMJAWhi5nPdg5Q9zHz6lxtN8kp/VdMlhi/Q==}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -3391,6 +3419,13 @@ packages:
 
   monaco-editor@0.34.1:
     resolution: {integrity: sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==}
+
+  monocart-coverage-reports@2.12.12:
+    resolution: {integrity: sha512-d9FdUr2dn58Crweon0IE0zVi8r/i4vLvfvb2G7eL5vL5LfrxCB2X6F6qzuiwV6RioA4zbAI//7CYi6LjCvN3zA==}
+    hasBin: true
+
+  monocart-locator@1.0.3:
+    resolution: {integrity: sha512-pe29W2XAoA1WQmZZqxXoP7s06ZEXUhcb81086v68cqjk1HnVL7Q/iU/WJnnetxjPcLqwb4qG8vaSGUOMQU602g==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -6525,16 +6560,24 @@ snapshots:
 
   acorn-globals@7.0.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.18.0
       acorn-walk: 8.3.4
 
-  acorn-jsx@5.3.2(acorn@8.15.0):
+  acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.18.0
+
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.18.0
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.18.0
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.18.0
 
   acorn@8.15.0: {}
 
@@ -6890,6 +6933,8 @@ snapshots:
 
   commander@10.0.1: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@7.2.0: {}
@@ -6899,6 +6944,8 @@ snapshots:
   compute-scroll-into-view@3.1.1: {}
 
   concat-map@0.0.1: {}
+
+  console-grid@2.2.4: {}
 
   continuable-cache@0.3.1: {}
 
@@ -7295,6 +7342,8 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  eight-colors@1.3.3: {}
+
   electron-to-chromium@1.5.267: {}
 
   emittery@0.13.1: {}
@@ -7623,8 +7672,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 4.2.1
 
   esprima@4.0.1: {}
@@ -7751,6 +7800,10 @@ snapshots:
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  foreground-child@4.0.3:
+    dependencies:
       signal-exit: 4.1.0
 
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.2)(webpack@5.109.2):
@@ -8618,7 +8671,7 @@ snapshots:
   jsdom@20.0.3(supports-color@8.1.1):
     dependencies:
       abab: 2.0.6
-      acorn: 8.15.0
+      acorn: 8.18.0
       acorn-globals: 7.0.1
       cssom: 0.5.0
       cssstyle: 2.3.0
@@ -8728,6 +8781,8 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  lz-utils@2.1.1: {}
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
@@ -8832,6 +8887,23 @@ snapshots:
   moment@2.30.1: {}
 
   monaco-editor@0.34.1: {}
+
+  monocart-coverage-reports@2.12.12:
+    dependencies:
+      acorn: 8.18.0
+      acorn-loose: 8.5.2
+      acorn-walk: 8.3.5
+      commander: 14.0.3
+      console-grid: 2.2.4
+      eight-colors: 1.3.3
+      foreground-child: 4.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      lz-utils: 2.1.1
+      monocart-locator: 1.0.3
+
+  monocart-locator@1.0.3: {}
 
   ms@2.1.3: {}
 
@@ -8987,7 +9059,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -9985,7 +10057,7 @@ snapshots:
   terser@5.44.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 

--- a/scripts/e2e-coverage-report.sh
+++ b/scripts/e2e-coverage-report.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Renders the e2e coverage reports after a `pnpm e2e:coverage` run:
+#
+#   frontend  coverage/e2e-frontend/   (written by monocart via tests/fixtures.ts)
+#   backend   coverage/e2e-backend-raw (GOCOVERDIR counters flushed by the plugin
+#                                       binary, which must be built with -cover)
+#
+# Produces coverage/e2e-backend.cov (textfmt), coverage/e2e-backend.html and a
+# combined summary on stdout. When GITHUB_STEP_SUMMARY is set (CI), the same
+# summary is appended there as markdown.
+set -euo pipefail
+
+BACKEND_RAW="coverage/e2e-backend-raw"
+FRONTEND_SUMMARY="coverage/e2e-frontend/coverage-summary.json"
+
+summary() {
+  echo "$1"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "$1" >>"$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+summary "## E2E coverage"
+summary ""
+
+# --- Backend (Go) ---------------------------------------------------------
+if compgen -G "$BACKEND_RAW/covcounters.*" >/dev/null; then
+  go tool covdata textfmt -i="$BACKEND_RAW" -o coverage/e2e-backend.cov
+  go tool cover -html=coverage/e2e-backend.cov -o coverage/e2e-backend.html
+
+  echo "--- backend per-package coverage ---"
+  go tool covdata percent -i="$BACKEND_RAW"
+
+  BACKEND_TOTAL=$(go tool cover -func=coverage/e2e-backend.cov | awk '/^total:/ {print $3}')
+  summary "- **Backend (Go, pkg/...)**: ${BACKEND_TOTAL} of statements (report: coverage/e2e-backend.html)"
+else
+  summary "- **Backend (Go, pkg/...)**: no coverage data found in ${BACKEND_RAW} (was the plugin built with \`go build -cover\`?)"
+fi
+
+# --- Frontend (TypeScript) ------------------------------------------------
+if [ -f "$FRONTEND_SUMMARY" ]; then
+  FRONTEND_LINES=$(jq -r '.total.lines.pct' "$FRONTEND_SUMMARY")
+  FRONTEND_BRANCHES=$(jq -r '.total.branches.pct' "$FRONTEND_SUMMARY")
+  summary "- **Frontend (TypeScript, src/...)**: ${FRONTEND_LINES}% lines, ${FRONTEND_BRANCHES}% branches (report: coverage/e2e-frontend/index.html)"
+else
+  summary "- **Frontend (TypeScript, src/...)**: no coverage data found (run with E2E_COVERAGE=true)"
+fi

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,71 @@
+# End-to-end tests
+
+Playwright suite that exercises the datasource against a real Grafana and a
+mock Factry Historian API.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `mockhistorian/` | Go mock of the Historian REST API. Reuses `pkg/schemas` and `pkg/proto` so JSON shapes and the protobuf/Arrow query responses stay byte-faithful to what the backend decodes. Covered by its own unit tests, plus integration tests (`datasource_integration_test.go`) that drive the real plugin backend against the mock with the same query payloads as the provisioned dashboards. |
+| `provisioning/` | Grafana provisioning used only for e2e: one datasource pointing at the mock, plus one dashboard per query type (measurements, assets, events, raw). |
+| `*.spec.ts` | The Playwright specs. They import `test`/`expect` from `./fixtures` (not `@grafana/plugin-e2e`) so coverage collection hooks into every test. |
+| `fixtures.ts`, `utils.ts`, `coverage/` | Shared fixtures, selector helpers and coverage plumbing. |
+
+## Fixture dataset
+
+The mock serves a small deterministic plant:
+
+- Database `historian` (QuestDB)
+- Measurements `e2e.motor.speed` and `e2e.motor.temperature`, with tags `location` and `unit`
+- Asset tree `Site \\ Line 1 \\ Motor`, Motor has properties `Speed` and `Temperature`
+- Event type `Batch` (simple properties `code`, `good`, `yield`) configured on Motor
+- Three batch events (`batch-41`..`batch-43`, the last one still open), generated relative to the queried time range so they always fall inside the dashboard window
+
+## Running locally
+
+```sh
+# 1. Build the plugin (backend + frontend) into dist/
+mage buildAll && pnpm build
+
+# 2. Start Grafana + mock Historian (Grafana on http://localhost:3001)
+pnpm server:e2e
+
+# 3. Run the suite
+pnpm e2e
+```
+
+## Coverage
+
+`pnpm e2e:coverage` runs the same suite with coverage reporting on both sides
+of the plugin:
+
+- **Frontend**: every test collects V8 coverage from Chromium
+  (`tests/fixtures.ts`), and the global teardown maps it back to `src/`
+  through the production source map using `monocart-coverage-reports`.
+  Output: console summary + `coverage/e2e-frontend/` (HTML, lcov,
+  `coverage-summary.json`).
+- **Backend**: build the plugin binary with coverage instrumentation first:
+
+  ```sh
+  go build -cover -covermode=atomic -coverpkg=./pkg/... \
+    -o dist/gpx_factry-historian-datasource_linux_amd64 ./pkg
+  mkdir -p coverage/e2e-backend-raw && chmod 777 coverage/e2e-backend-raw
+  ```
+
+  `docker-compose.e2e.yaml` sets `GOCOVERDIR` and forwards it to the plugin
+  subprocess; `pkg/coverageflush.go` flushes counters every 15s (Grafana kills
+  the plugin on shutdown, so the usual write-at-exit never runs). Raw counter
+  files land in `coverage/e2e-backend-raw/`.
+
+Render the combined report (also used by CI for the job summary):
+
+```sh
+bash scripts/e2e-coverage-report.sh
+```
+
+This writes `coverage/e2e-backend.cov`, `coverage/e2e-backend.html` and prints
+per-package backend percentages plus the frontend totals.
+
+In CI the `playwright-tests` job does all of the above per Grafana version and
+uploads `e2e-coverage-*` artifacts with the HTML reports.

--- a/tests/annotations.spec.ts
+++ b/tests/annotations.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from './fixtures';
+import { inlineFieldInput, selectCascaderPath } from './utils';
+
+// Annotations reuse the Events editor restricted to the "simple" property
+// type; the annotation query itself runs the same EventQuery backend path.
+test.describe('annotations', () => {
+  test('annotation editor builds an event query that returns events', async ({
+    annotationEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await annotationEditPage.datasource.set(ds.name);
+
+    await expect(page.getByText('Event query', { exact: true })).toBeVisible();
+
+    // Select the Motor asset through the cascader, then the Batch event type.
+    await selectCascaderPath(page, inlineFieldInput(page, 'Assets'), ['Site', 'Line 1', 'Motor']);
+    await inlineFieldInput(page, 'Event types').click();
+    await page.getByRole('option', { name: 'Batch' }).click();
+
+    await expect(annotationEditPage.runQuery()).toBeOK();
+  });
+});

--- a/tests/assetsQuery.spec.ts
+++ b/tests/assetsQuery.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from './fixtures';
+import { enableTableView, inlineFieldInput, selectCascaderPath } from './utils';
+
+test.describe('assets query', () => {
+  test('provisioned dashboard renders asset property data', async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+  }) => {
+    const dashboard = await readProvisionedDashboard({ fileName: 'assets.json' });
+    const dashboardPage = await gotoDashboardPage(dashboard);
+
+    // AssetMeasurementQuery end-to-end: the backend resolves the Motor asset
+    // (UUIDs[i] filter), fetches its properties, queries both measurements and
+    // renames the frames to "<asset path>\\<property>". The table panel only
+    // renders the first frame (alphabetically Speed); the multi-frame naming
+    // is covered by the backend integration test in tests/mockhistorian.
+    const panel = dashboardPage.getPanelByTitle('Motor properties');
+    await expect(panel.getErrorIcon()).toBeHidden();
+    await expect(panel.locator).toContainText('Motor');
+    await expect(panel.locator).toContainText('Speed');
+  });
+
+  test('an asset property picked through the cascader returns data', async ({
+    panelEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await panelEditPage.datasource.set(ds.name);
+    await enableTableView(page);
+
+    // Assets is the default tab. Walk the lazy-loading cascader down to an
+    // asset property leaf; each level is fetched from the mock on demand.
+    await selectCascaderPath(page, inlineFieldInput(page, 'Assets'), ['Site', 'Line 1', 'Motor', 'Speed']);
+
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+    await expect(panelEditPage.panel.locator).toContainText('Speed');
+  });
+});

--- a/tests/configEditor.spec.ts
+++ b/tests/configEditor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@grafana/plugin-e2e';
+import { test, expect } from './fixtures';
 
 const PLUGIN_ID = 'factry-historian-datasource';
 
@@ -16,5 +16,17 @@ test.describe('config editor', () => {
     // Save & test triggers the backend CheckHealth -> GET /api/timeseries-databases
     // on the mock, which returns one database.
     await expect(configPage.saveAndTest()).toBeOK();
+  });
+
+  test('an unreachable historian fails the health check', async ({ createDataSourceConfigPage, page }) => {
+    const configPage = await createDataSourceConfigPage({ type: PLUGIN_ID });
+
+    // Port 9999 is not bound in the mock container: the backend health check
+    // must surface an error instead of a false positive.
+    await page.getByPlaceholder('http://127.0.0.1:8000').fill('http://mockhistorian:9999');
+    await page.locator('input[name="organization"]').fill('00000000-0000-0000-0000-000000000000');
+    await page.getByPlaceholder('token').fill('e2e-mock-token');
+
+    await expect(configPage.saveAndTest()).not.toBeOK();
   });
 });

--- a/tests/coverage/global-setup.ts
+++ b/tests/coverage/global-setup.ts
@@ -1,0 +1,11 @@
+import MCR from 'monocart-coverage-reports';
+import { coverageEnabled, coverageOptions } from './options';
+
+// Clears cached coverage data from previous runs so every `pnpm e2e:coverage`
+// starts from a clean slate.
+export default function globalSetup(): void {
+  if (!coverageEnabled) {
+    return;
+  }
+  MCR(coverageOptions).cleanCache();
+}

--- a/tests/coverage/global-teardown.ts
+++ b/tests/coverage/global-teardown.ts
@@ -1,0 +1,11 @@
+import MCR from 'monocart-coverage-reports';
+import { coverageEnabled, coverageOptions } from './options';
+
+// Generates the frontend coverage report (console summary + HTML + lcov +
+// json-summary) from the data every test added via tests/fixtures.ts.
+export default async function globalTeardown(): Promise<void> {
+  if (!coverageEnabled) {
+    return;
+  }
+  await MCR(coverageOptions).generate();
+}

--- a/tests/coverage/options.ts
+++ b/tests/coverage/options.ts
@@ -1,0 +1,30 @@
+import type { CoverageReportOptions } from 'monocart-coverage-reports';
+
+// Frontend e2e coverage is collected from Chromium's V8 coverage API and
+// mapped back to the original src/ files through the production source map
+// (module.js.map). Enabled when E2E_COVERAGE=true.
+export const coverageEnabled = process.env.E2E_COVERAGE === 'true';
+
+export const coverageOptions: CoverageReportOptions = {
+  name: 'Factry Historian datasource e2e frontend coverage',
+  outputDir: './coverage/e2e-frontend',
+
+  reports: [
+    // Human-readable summary in the terminal / CI log.
+    ['console-summary'],
+    // Browsable HTML report with per-file line coverage.
+    ['v8'],
+    // Machine-readable outputs for CI summaries and external tooling.
+    ['json-summary'],
+    ['lcovonly', { file: 'lcov.info' }],
+  ],
+
+  // Only the plugin bundle; Grafana's own bundles are not under test.
+  entryFilter: (entry) => entry.url.includes('/plugins/factry-historian-datasource/module.js'),
+
+  // Only original plugin sources, not webpack runtime, AMD externals or
+  // node_modules. The webpack config sets rootDir to src/, so source paths in
+  // the map are relative to it WITHOUT a src/ prefix (e.g. "datasource.ts",
+  // "QueryEditor/Assets.tsx").
+  sourceFilter: (sourcePath) => /\.(ts|tsx)$/.test(sourcePath) && !sourcePath.includes('node_modules'),
+};

--- a/tests/eventsQuery.spec.ts
+++ b/tests/eventsQuery.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from './fixtures';
+import { enableTableView, inlineFieldInput, selectCascaderPath } from './utils';
+
+test.describe('events query', () => {
+  test('provisioned dashboard renders batch events as a table', async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+  }) => {
+    const dashboard = await readProvisionedDashboard({ fileName: 'events.json' });
+    const dashboardPage = await gotoDashboardPage(dashboard);
+
+    // EventQuery end-to-end: the backend resolves asset + event type, fetches
+    // events (GET /api/events) and event type properties, and converts them to
+    // a table frame with one column per simple property. Assert on the fixed
+    // event UUIDs (first column): the property columns often sit outside the
+    // virtualized table viewport and would not be rendered as text.
+    const panel = dashboardPage.getPanelByTitle('Batch events');
+    await expect(panel.getErrorIcon()).toBeHidden();
+    await expect(panel.locator).toContainText('Batch');
+    await expect(panel.locator).toContainText('12121212-1212-1212-1212-121212121212');
+    await expect(panel.locator).toContainText('13131313-1313-1313-1313-131313131313');
+    // The open event (no stop time) must render too.
+    await expect(panel.locator).toContainText('14141414-1414-1414-1414-141414141414');
+  });
+
+  test('an event query built in the editor returns events', async ({
+    panelEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await panelEditPage.datasource.set(ds.name);
+    await enableTableView(page);
+
+    await page.getByRole('radio', { name: 'Events' }).check({ force: true });
+
+    // Select the Motor asset through the lazy-loading cascader.
+    await selectCascaderPath(page, inlineFieldInput(page, 'Assets'), ['Site', 'Line 1', 'Motor']);
+
+    // Event types are filtered by the event configurations of the selected
+    // asset; the mock links Batch to the Motor asset.
+    await inlineFieldInput(page, 'Event types').click();
+    await page.getByRole('option', { name: 'Batch' }).click();
+
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+    // The panel renders event data differently per Grafana version: as a table
+    // (leading EventUUID column visible) or as a timeseries legend with the
+    // numeric property series. Accept either; both prove the event query
+    // returned the batch events, while "No data" or an error match neither.
+    await expect(panelEditPage.panel.locator).toContainText(
+      /13131313-1313-1313-1313-131313131313|yield/
+    );
+  });
+});

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,29 @@
+import { test as base } from '@grafana/plugin-e2e';
+import MCR from 'monocart-coverage-reports';
+import { coverageEnabled, coverageOptions } from './coverage/options';
+
+// Wraps @grafana/plugin-e2e's test with an automatic fixture that collects V8
+// JS coverage for every test when E2E_COVERAGE=true. All specs must import
+// { test, expect } from this file instead of '@grafana/plugin-e2e'.
+export const test = base.extend<{ collectCoverage: void }>({
+  collectCoverage: [
+    async ({ page, browserName }, use) => {
+      const collecting = coverageEnabled && browserName === 'chromium';
+      if (collecting) {
+        await page.coverage.startJSCoverage({ resetOnNavigation: false });
+      }
+
+      await use();
+
+      if (collecting) {
+        const coverage = await page.coverage.stopJSCoverage();
+        // MCR caches raw data on disk, so parallel workers all add to the
+        // same report; the global teardown generates it once.
+        await MCR(coverageOptions).add(coverage);
+      }
+    },
+    { auto: true },
+  ],
+});
+
+export { expect } from '@grafana/plugin-e2e';

--- a/tests/measurementsQuery.spec.ts
+++ b/tests/measurementsQuery.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@grafana/plugin-e2e';
+import { test, expect } from './fixtures';
+import { enableTableView, inlineFieldInput } from './utils';
 
 test.describe('measurements query', () => {
   test('provisioned dashboard renders data from the mock Historian', async ({
@@ -20,16 +21,48 @@ test.describe('measurements query', () => {
     await expect(panel.locator).toContainText('e2e.motor.speed');
   });
 
-  test('query editor exposes the four query-type tabs', async ({
+  test('a measurement picked in the query editor returns data', async ({
     panelEditPage,
     readProvisionedDataSource,
     page,
   }) => {
     const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
     await panelEditPage.datasource.set(ds.name);
+    await enableTableView(page);
 
-    for (const tab of ['Assets', 'Measurements', 'Events', 'Raw']) {
-      await expect(page.getByRole('radio', { name: tab })).toBeVisible();
-    }
+    await page.getByRole('radio', { name: 'Measurements' }).check({ force: true });
+    await expect(page.getByText('select measurement')).toBeVisible();
+    // The measurement select remounts once the database list resolves
+    // (key={selectedDatabases}), which would destroy the input mid-typing.
+    await page.waitForTimeout(1500);
+
+    // Type into the combobox input; the options load from the mock's
+    // /api/measurements with the typed keyword.
+    await inlineFieldInput(page, 'Measurements').pressSequentially('temperature', { delay: 40 });
+    await page.getByRole('option', { name: /e2e\.motor\.temperature/ }).click();
+
+    // Selecting a measurement triggers the query; the rendered table proves the
+    // full frontend -> backend -> mock -> Arrow decode path.
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+    await expect(panelEditPage.panel.locator).toContainText('e2e.motor.temperature');
+  });
+
+  test('regex mode queries all matching measurements', async ({
+    panelEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await panelEditPage.datasource.set(ds.name);
+    await enableTableView(page);
+
+    await page.getByRole('radio', { name: 'Measurements' }).check({ force: true });
+    await page.getByText('Use regular expression').click();
+
+    await page.getByPlaceholder('[m|M]otor_[0-9]').fill('e2e\\.motor\\..*');
+
+    // The regex input debounces for 500ms before it updates the query.
+    await expect(panelEditPage.refreshPanel()).toBeOK();
+    await expect(panelEditPage.panel.locator).toContainText('e2e.motor.speed');
   });
 });

--- a/tests/measurementsQuery.spec.ts
+++ b/tests/measurementsQuery.spec.ts
@@ -32,9 +32,16 @@ test.describe('measurements query', () => {
 
     await page.getByRole('radio', { name: 'Measurements' }).check({ force: true });
     await expect(page.getByText('select measurement')).toBeVisible();
-    // The measurement select remounts once the database list resolves
-    // (key={selectedDatabases}), which would destroy the input mid-typing.
-    await page.waitForTimeout(1500);
+
+    // The measurement select remounts whenever the number of selected databases
+    // changes (key={props.selectedDatabases?.length}), which would destroy the
+    // input mid-typing. Picking a database is the deterministic wait for that:
+    // the option can only render after the database list resolved (the same
+    // promise sets selectedDatabases before returning the options), and the
+    // click is then the last remount before we type.
+    await inlineFieldInput(page, 'Database').pressSequentially('historian', { delay: 40 });
+    await page.getByRole('option', { name: 'historian' }).click();
+    await page.keyboard.press('Tab');
 
     // Type into the combobox input; the options load from the mock's
     // /api/measurements with the typed keyword.
@@ -59,9 +66,22 @@ test.describe('measurements query', () => {
     await page.getByRole('radio', { name: 'Measurements' }).check({ force: true });
     await page.getByText('Use regular expression').click();
 
-    await page.getByPlaceholder('[m|M]otor_[0-9]').fill('e2e\\.motor\\..*');
+    // The regex input debounces for 500ms before it commits to the query, so
+    // wait for the run that debounce triggers rather than racing it: calling
+    // refreshPanel() straight after fill() asserts a query with no Regex set,
+    // and only passes because the debounced run lands while toContainText is
+    // still polling. JSON.stringify gives the exact quoted form the regex takes
+    // in the request body.
+    const regex = 'e2e\\.motor\\..*';
+    const debouncedRun = page.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes('/api/ds/query') &&
+        (request.postData() ?? '').includes(JSON.stringify(regex))
+    );
+    await page.getByPlaceholder('[m|M]otor_[0-9]').fill(regex);
+    await debouncedRun;
 
-    // The regex input debounces for 500ms before it updates the query.
     await expect(panelEditPage.refreshPanel()).toBeOK();
     await expect(panelEditPage.panel.locator).toContainText('e2e.motor.speed');
   });

--- a/tests/mockhistorian/datasource_integration_test.go
+++ b/tests/mockhistorian/datasource_integration_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/datasource"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests drive the real plugin backend (pkg/datasource) against the mock
+// exactly like Grafana does in the e2e suite: same instance settings, same
+// query payloads as the provisioned dashboards. They catch contract breaks
+// between the backend and the mock without needing a browser.
+
+func newTestDataSource(t *testing.T) *datasource.HistorianDataSource {
+	t.Helper()
+
+	server := httptest.NewServer(newMux())
+	t.Cleanup(server.Close)
+
+	instance, err := datasource.NewDataSource(context.Background(), backend.DataSourceInstanceSettings{
+		JSONData:                []byte(`{"url": "` + server.URL + `", "organization": "00000000-0000-0000-0000-000000000000"}`),
+		DecryptedSecureJSONData: map[string]string{"token": "e2e-mock-token"},
+	})
+	require.NoError(t, err)
+	ds, ok := instance.(*datasource.HistorianDataSource)
+	require.True(t, ok)
+	return ds
+}
+
+func testTimeRange() backend.TimeRange {
+	to := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	return backend.TimeRange{From: to.Add(-6 * time.Hour), To: to}
+}
+
+// queryJSON builds the payload the frontend sends: the inner query under
+// "query" plus seriesLimit (see pkg/datasource/query_handler.go Query).
+func queryJSON(t *testing.T, inner string) []byte {
+	t.Helper()
+
+	raw := map[string]any{"seriesLimit": 50}
+	var innerParsed any
+	require.NoError(t, json.Unmarshal([]byte(inner), &innerParsed))
+	raw["query"] = innerParsed
+	payload, err := json.Marshal(raw)
+	require.NoError(t, err)
+	return payload
+}
+
+func runQuery(t *testing.T, ds *datasource.HistorianDataSource, queryType, inner string) backend.DataResponse {
+	t.Helper()
+
+	response, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+		Queries: []backend.DataQuery{{
+			RefID:     "A",
+			QueryType: queryType,
+			TimeRange: testTimeRange(),
+			Interval:  time.Minute,
+			JSON:      queryJSON(t, inner),
+		}},
+	})
+	require.NoError(t, err)
+	return response.Responses["A"]
+}
+
+func TestDataSourceCheckHealth(t *testing.T) {
+	t.Parallel()
+
+	ds := newTestDataSource(t)
+	result, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, backend.HealthStatusOk, result.Status, result.Message)
+}
+
+func TestDataSourceMeasurementQuery(t *testing.T) {
+	t.Parallel()
+
+	// Same query as tests/provisioning/dashboards/measurements.json.
+	response := runQuery(t, newTestDataSource(t), "MeasurementQuery", `{
+		"Databases": ["historian"],
+		"Measurements": ["e2e.motor.speed"],
+		"IsRegex": false,
+		"Options": {
+			"Aggregation": { "Name": "mean", "Period": "$__interval" },
+			"GroupBy": [], "Tags": {}
+		}
+	}`)
+	require.NoError(t, response.Error)
+	require.Len(t, response.Frames, 1)
+
+	valueField, idx := response.Frames[0].FieldByName("value")
+	require.NotEqual(t, -1, idx)
+	assert.Positive(t, valueField.Len())
+	require.NotNil(t, valueField.Config)
+	assert.Contains(t, valueField.Config.DisplayNameFromDS, "e2e.motor.speed")
+}
+
+func TestDataSourceAssetMeasurementQuery(t *testing.T) {
+	t.Parallel()
+
+	// Same query as tests/provisioning/dashboards/assets.json.
+	response := runQuery(t, newTestDataSource(t), "AssetMeasurementQuery", `{
+		"Assets": ["66666666-6666-6666-6666-666666666666"],
+		"AssetProperties": ["Speed", "Temperature"],
+		"Options": {
+			"Aggregation": { "Name": "mean", "Period": "$__interval" },
+			"GroupBy": [], "Tags": {}
+		}
+	}`)
+	require.NoError(t, response.Error)
+	require.Len(t, response.Frames, 2)
+
+	names := make([]string, 0, len(response.Frames))
+	for _, frame := range response.Frames {
+		valueField, idx := frame.FieldByName("value")
+		require.NotEqual(t, -1, idx)
+		require.NotNil(t, valueField.Config)
+		names = append(names, valueField.Config.DisplayNameFromDS)
+	}
+	assert.Contains(t, names[0]+names[1], "Speed")
+	assert.Contains(t, names[0]+names[1], "Temperature")
+}
+
+func TestDataSourceEventQuery(t *testing.T) {
+	t.Parallel()
+
+	// Same query as tests/provisioning/dashboards/events.json.
+	response := runQuery(t, newTestDataSource(t), "EventQuery", `{
+		"Type": "simple",
+		"Assets": ["66666666-6666-6666-6666-666666666666"],
+		"EventTypes": ["99999999-9999-9999-9999-999999999999"],
+		"Statuses": [], "Properties": [], "PropertyFilter": [],
+		"Limit": 1000,
+		"Ascending": true
+	}`)
+	require.NoError(t, response.Error)
+	require.Len(t, response.Frames, 1)
+
+	codeField, idx := response.Frames[0].FieldByName("code")
+	require.NotEqual(t, -1, idx, "expected a column per simple event property")
+	require.Equal(t, 3, codeField.Len())
+
+	codes := map[string]struct{}{}
+	for i := 0; i < codeField.Len(); i++ {
+		value, ok := codeField.ConcreteAt(i)
+		require.True(t, ok)
+		codes[value.(string)] = struct{}{}
+	}
+	assert.Contains(t, codes, "batch-42")
+}
+
+func TestDataSourceRawQuery(t *testing.T) {
+	t.Parallel()
+
+	// Same query as tests/provisioning/dashboards/raw.json.
+	response := runQuery(t, newTestDataSource(t), "RawQuery", `{
+		"TimeseriesDatabase": "11111111-1111-1111-1111-111111111111",
+		"Query": "SELECT time, value FROM \"e2e.motor.speed\" WHERE $timeFilter",
+		"Format": "arrow"
+	}`)
+	require.NoError(t, response.Error)
+	require.Len(t, response.Frames, 1)
+
+	labelField, idx := response.Frames[0].FieldByName("label")
+	require.NotEqual(t, -1, idx)
+	assert.Equal(t, "raw-row-1", labelField.At(0))
+}

--- a/tests/mockhistorian/events.go
+++ b/tests/mockhistorian/events.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+)
+
+// handleEvents implements GET /api/events for the form-encoded
+// schemas.EventFilter the backend sends. Events are generated relative to the
+// requested [StartTime, StopTime] window so they always land inside the
+// dashboard's time range.
+func handleEvents(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	end := time.Now().UTC()
+	if t, ok := paramTime(q, "StopTime"); ok {
+		end = t
+	}
+	start := end.Add(-6 * time.Hour)
+	if t, ok := paramTime(q, "StartTime"); ok {
+		start = t
+	}
+	if !end.After(start) {
+		end = start.Add(time.Hour)
+	}
+
+	assetUUIDs := param(q, "AssetUUIDs")
+	eventTypeUUIDs := param(q, "EventTypeUUIDs")
+	statuses := param(q, "Status")
+	limit := paramInt(q, "Limit")
+	ascending := paramBool(q, "Ascending")
+
+	result := []schemas.Event{}
+	events := eventsInRange(start, end)
+	for i := range events {
+		if len(assetUUIDs) > 0 && !containsUUID(assetUUIDs, events[i].AssetUUID) {
+			continue
+		}
+		if len(eventTypeUUIDs) > 0 && !containsUUID(eventTypeUUIDs, events[i].EventTypeUUID) {
+			continue
+		}
+		if len(statuses) > 0 && !slices.Contains(statuses, string(events[i].Status)) {
+			continue
+		}
+		if !matchesPropertyFilters(q, &events[i]) {
+			continue
+		}
+		result = append(result, events[i])
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if ascending {
+			return result[i].StartTime.Before(result[j].StartTime)
+		}
+		return result[i].StartTime.After(result[j].StartTime)
+	})
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	writeJSON(w, result)
+}
+
+// matchesPropertyFilters applies the PropertyFilter[i].* query parameters.
+// Only the operators the e2e suite exercises are implemented; unknown
+// operators match everything so new UI options degrade gracefully.
+func matchesPropertyFilters(q map[string][]string, event *schemas.Event) bool {
+	values := func(key string) []string {
+		if v, ok := q[key]; ok {
+			return v
+		}
+		return nil
+	}
+
+	for i := 0; ; i++ {
+		prefix := fmt.Sprintf("PropertyFilter[%d]", i)
+		property := values(prefix + ".Property")
+		if property == nil {
+			return true
+		}
+		operator := ""
+		if op := values(prefix + ".Operator"); len(op) > 0 {
+			operator = op[0]
+		}
+		filterValues := values(prefix + ".Value")
+		if indexed := values(prefix + ".Value[0]"); indexed != nil {
+			filterValues = indexed
+		}
+
+		var actual any
+		if event.Properties != nil {
+			actual = event.Properties.Properties[property[0]]
+		}
+
+		switch operator {
+		case "EXISTS", "IS NOT NULL":
+			if actual == nil {
+				return false
+			}
+		case "NOT EXISTS", "IS NULL":
+			if actual != nil {
+				return false
+			}
+		case "=", "==", "":
+			if len(filterValues) == 0 || fmt.Sprintf("%v", actual) != filterValues[0] {
+				return false
+			}
+		case "!=", "<>":
+			if len(filterValues) == 0 || fmt.Sprintf("%v", actual) == filterValues[0] {
+				return false
+			}
+		}
+	}
+}
+
+// handleEventPropertyValues implements
+// GET /api/event-type-properties/{uuid}/values: the distinct values of one
+// event type property across the events in range.
+func handleEventPropertyValues(w http.ResponseWriter, r *http.Request) {
+	propertyUUID, err := uuid.Parse(r.PathValue("uuid"))
+	if err != nil {
+		http.Error(w, "invalid uuid", http.StatusBadRequest)
+		return
+	}
+
+	var propertyName string
+	for _, property := range eventTypeProperties {
+		if property.UUID == propertyUUID {
+			propertyName = property.Name
+		}
+	}
+	if propertyName == "" {
+		http.Error(w, "event type property not found", http.StatusNotFound)
+		return
+	}
+
+	q := r.URL.Query()
+	end := time.Now().UTC()
+	if t, ok := paramTime(q, "StopTime"); ok {
+		end = t
+	}
+	start := end.Add(-6 * time.Hour)
+	if t, ok := paramTime(q, "StartTime"); ok {
+		start = t
+	}
+
+	seen := map[string]struct{}{}
+	values := []any{}
+	events := eventsInRange(start, end)
+	for i := range events {
+		if events[i].Properties == nil {
+			continue
+		}
+		value, ok := events[i].Properties.Properties[propertyName]
+		if !ok {
+			continue
+		}
+		key := fmt.Sprintf("%v", value)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		values = append(values, value)
+	}
+	writeJSON(w, values)
+}

--- a/tests/mockhistorian/fixtures.go
+++ b/tests/mockhistorian/fixtures.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+)
+
+// Fixtures form a small deterministic "plant": one timeseries database, a
+// three-level asset tree (Site \\ Line 1 \\ Motor), two asset properties
+// backed by measurements, and a Batch event type configured on the Motor
+// asset. UUIDs are fixed so tests can assert against them.
+var (
+	databaseUUID = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	speedMeasurementUUID       = uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	temperatureMeasurementUUID = uuid.MustParse("33333333-3333-3333-3333-333333333333")
+
+	siteAssetUUID  = uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	lineAssetUUID  = uuid.MustParse("55555555-5555-5555-5555-555555555555")
+	motorAssetUUID = uuid.MustParse("66666666-6666-6666-6666-666666666666")
+
+	speedPropertyUUID       = uuid.MustParse("77777777-7777-7777-7777-777777777777")
+	temperaturePropertyUUID = uuid.MustParse("88888888-8888-8888-8888-888888888888")
+
+	batchEventTypeUUID = uuid.MustParse("99999999-9999-9999-9999-999999999999")
+
+	codePropertyUUID  = uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	goodPropertyUUID  = uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	yieldPropertyUUID = uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+	eventConfigurationUUID = uuid.MustParse("dddddddd-dddd-dddd-dddd-dddddddddddd")
+
+	collectorUUID = uuid.MustParse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
+)
+
+var database = schemas.TimeseriesDatabase{
+	BaseModel:              schemas.BaseModel{UUID: databaseUUID, Name: "historian"},
+	TimeseriesDatabaseType: &schemas.TimeseriesDatabaseType{Name: "QuestDB"},
+	Description:            "Mock timeseries database for e2e tests",
+}
+
+var collector = schemas.Collector{
+	BaseModel:     schemas.BaseModel{UUID: collectorUUID, Name: "e2e-collector"},
+	Description:   "Mock collector for e2e tests",
+	CollectorType: "OPCUA",
+}
+
+var measurements = []schemas.Measurement{
+	{
+		BaseModel:     schemas.BaseModel{UUID: speedMeasurementUUID, Name: "e2e.motor.speed"},
+		Database:      &database,
+		DatabaseUUID:  databaseUUID,
+		Collector:     &collector,
+		CollectorUUID: collectorUUID,
+		Datatype:      "float64",
+		Status:        "Good",
+		Description:   "Mock motor speed for e2e tests",
+	},
+	{
+		BaseModel:     schemas.BaseModel{UUID: temperatureMeasurementUUID, Name: "e2e.motor.temperature"},
+		Database:      &database,
+		DatabaseUUID:  databaseUUID,
+		Collector:     &collector,
+		CollectorUUID: collectorUUID,
+		Datatype:      "float64",
+		Status:        "Good",
+		Description:   "Mock motor temperature for e2e tests",
+	},
+}
+
+// tagsPerMeasurement backs the tag key/value endpoints.
+var tagsPerMeasurement = map[uuid.UUID]map[string][]string{
+	speedMeasurementUUID: {
+		"location": {"ghent", "aalst"},
+		"unit":     {"rpm"},
+	},
+	temperatureMeasurementUUID: {
+		"location": {"ghent"},
+		"unit":     {"degC"},
+	},
+}
+
+// assets returns the asset tree. Built as a function (not a package var) so
+// the HasChildren/HasAssetProperties pointers cannot be mutated between
+// requests; the datasource only expects them when the matching Include* flag
+// is set, which the handler decides per request.
+func assets() []schemas.Asset {
+	return []schemas.Asset{
+		{
+			BaseModel:          schemas.BaseModel{UUID: siteAssetUUID, Name: "Site"},
+			Description:        "Mock site",
+			Status:             "active",
+			AssetPath:          `Site`,
+			HasChildren:        new(true),
+			HasAssetProperties: new(false),
+		},
+		{
+			BaseModel:          schemas.BaseModel{UUID: lineAssetUUID, Name: "Line 1"},
+			ParentUUID:         &siteAssetUUID,
+			Description:        "Mock production line",
+			Status:             "active",
+			AssetPath:          `Site\\Line 1`,
+			HasChildren:        new(true),
+			HasAssetProperties: new(false),
+		},
+		{
+			BaseModel:          schemas.BaseModel{UUID: motorAssetUUID, Name: "Motor"},
+			ParentUUID:         &lineAssetUUID,
+			Description:        "Mock motor asset",
+			Status:             "active",
+			AssetPath:          `Site\\Line 1\\Motor`,
+			HasChildren:        new(false),
+			HasAssetProperties: new(true),
+		},
+	}
+}
+
+var assetProperties = []schemas.AssetProperty{
+	{
+		BaseModel:       schemas.BaseModel{UUID: speedPropertyUUID, Name: "Speed"},
+		AssetUUID:       motorAssetUUID,
+		MeasurementUUID: speedMeasurementUUID,
+	},
+	{
+		BaseModel:       schemas.BaseModel{UUID: temperaturePropertyUUID, Name: "Temperature"},
+		AssetUUID:       motorAssetUUID,
+		MeasurementUUID: temperatureMeasurementUUID,
+	},
+}
+
+var eventTypeProperties = []schemas.EventTypeProperty{
+	{
+		BaseModel:     schemas.BaseModel{UUID: codePropertyUUID, Name: "code"},
+		Datatype:      schemas.EventTypePropertyDatatypeString,
+		Type:          schemas.EventTypePropertyTypeSimple,
+		EventTypeUUID: batchEventTypeUUID,
+	},
+	{
+		BaseModel:     schemas.BaseModel{UUID: goodPropertyUUID, Name: "good"},
+		Datatype:      schemas.EventTypePropertyDatatypeBool,
+		Type:          schemas.EventTypePropertyTypeSimple,
+		EventTypeUUID: batchEventTypeUUID,
+	},
+	{
+		BaseModel:     schemas.BaseModel{UUID: yieldPropertyUUID, Name: "yield"},
+		Datatype:      schemas.EventTypePropertyDatatypeNumber,
+		Type:          schemas.EventTypePropertyTypeSimple,
+		EventTypeUUID: batchEventTypeUUID,
+		UoM:           "%",
+	},
+}
+
+var eventTypes = []schemas.EventType{
+	{
+		BaseModel:   schemas.BaseModel{UUID: batchEventTypeUUID, Name: "Batch"},
+		Description: "Mock batch event type",
+		Properties:  eventTypeProperties,
+	},
+}
+
+var eventConfigurations = []schemas.EventConfiguration{
+	{
+		BaseModel:     schemas.BaseModel{UUID: eventConfigurationUUID, Name: "Motor batches"},
+		AssetUUID:     motorAssetUUID,
+		EventTypeUUID: batchEventTypeUUID,
+	},
+}
+
+// eventFixture describes one deterministic event relative to the queried
+// time range: offsets are fractions of the range so events always fall
+// inside the dashboard's window regardless of when the test runs.
+type eventFixture struct {
+	uuid          uuid.UUID
+	startFraction float64  // position of StartTime inside [start, end]
+	stopFraction  *float64 // nil = still open
+	status        schemas.EventStatus
+	properties    schemas.Attributes
+}
+
+var eventFixtures = []eventFixture{
+	{
+		uuid:          uuid.MustParse("12121212-1212-1212-1212-121212121212"),
+		startFraction: 0.10,
+		stopFraction:  new(0.35),
+		status:        schemas.EventStatusProcessed,
+		properties:    schemas.Attributes{"code": "batch-41", "good": true, "yield": 92.5},
+	},
+	{
+		uuid:          uuid.MustParse("13131313-1313-1313-1313-131313131313"),
+		startFraction: 0.40,
+		stopFraction:  new(0.70),
+		status:        schemas.EventStatusProcessed,
+		properties:    schemas.Attributes{"code": "batch-42", "good": false, "yield": 55.0},
+	},
+	{
+		uuid:          uuid.MustParse("14141414-1414-1414-1414-141414141414"),
+		startFraction: 0.75,
+		stopFraction:  nil,
+		status:        schemas.EventStatusOpen,
+		properties:    schemas.Attributes{"code": "batch-43", "good": true, "yield": 88.0},
+	},
+}
+
+// eventsInRange materializes the event fixtures inside [start, end].
+func eventsInRange(start, end time.Time) []schemas.Event {
+	span := end.Sub(start)
+	events := make([]schemas.Event, 0, len(eventFixtures))
+	for _, fixture := range eventFixtures {
+		properties := fixture.properties
+		event := schemas.Event{
+			UUID:                   fixture.uuid,
+			AssetUUID:              motorAssetUUID,
+			EventTypeUUID:          batchEventTypeUUID,
+			EventConfigurationUUID: eventConfigurationUUID,
+			Source:                 schemas.EventSourceAutomatic,
+			Status:                 fixture.status,
+			StartTime:              start.Add(time.Duration(fixture.startFraction * float64(span))),
+			Properties: &schemas.EventProperties{
+				EventUUID:  fixture.uuid,
+				Properties: properties,
+			},
+		}
+		if fixture.stopFraction != nil {
+			stop := start.Add(time.Duration(*fixture.stopFraction * float64(span)))
+			event.StopTime = &stop
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func measurementByUUID(id uuid.UUID) (schemas.Measurement, bool) {
+	for i := range measurements {
+		if measurements[i].UUID == id {
+			return measurements[i], true
+		}
+	}
+	return schemas.Measurement{}, false
+}

--- a/tests/mockhistorian/handlers.go
+++ b/tests/mockhistorian/handlers.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+)
+
+// param collects a query parameter that callers encode either as a repeated
+// key (Grafana's resource client: `Key=a&Key=b`) or as an indexed key (the Go
+// backend's form encoding: `Key[0]=a&Key[1]=b`).
+func param(values url.Values, key string) []string {
+	result := append([]string{}, values[key]...)
+	for i := 0; ; i++ {
+		indexed, ok := values[fmt.Sprintf("%s[%d]", key, i)]
+		if !ok {
+			break
+		}
+		result = append(result, indexed...)
+	}
+	return result
+}
+
+func paramBool(values url.Values, key string) bool {
+	v, err := strconv.ParseBool(values.Get(key))
+	return err == nil && v
+}
+
+func paramInt(values url.Values, key string) int {
+	v, err := strconv.Atoi(values.Get(key))
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+func paramTime(values url.Values, key string) (time.Time, bool) {
+	raw := values.Get(key)
+	if raw == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05Z0700"} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// matchKeyword mimics the historian's search semantics closely enough for the
+// datasource: empty matches everything, `/…/` is a regular expression, a
+// parseable UUID matches the item's UUID, anything else is a substring match.
+func matchKeyword(keyword string, itemUUID uuid.UUID, texts ...string) bool {
+	if keyword == "" {
+		return true
+	}
+	if strings.HasPrefix(keyword, "/") && strings.HasSuffix(keyword, "/") && len(keyword) > 2 {
+		re, err := regexp.Compile(keyword[1 : len(keyword)-1])
+		if err != nil {
+			return false
+		}
+		return slices.ContainsFunc(texts, re.MatchString)
+	}
+	if parsed, err := uuid.Parse(keyword); err == nil {
+		return parsed == itemUUID
+	}
+	lowered := strings.ToLower(keyword)
+	return slices.ContainsFunc(texts, func(text string) bool {
+		return strings.Contains(strings.ToLower(text), lowered)
+	})
+}
+
+// matchPath matches an asset path filter: `/…/` is a regular expression,
+// anything else must match the full path exactly.
+func matchPath(filter, assetPath string) bool {
+	if strings.HasPrefix(filter, "/") && strings.HasSuffix(filter, "/") && len(filter) > 2 {
+		re, err := regexp.Compile(filter[1 : len(filter)-1])
+		if err != nil {
+			return false
+		}
+		return re.MatchString(assetPath)
+	}
+	return filter == assetPath
+}
+
+func containsUUID(values []string, id uuid.UUID) bool {
+	for _, value := range values {
+		if parsed, err := uuid.Parse(value); err == nil && parsed == id {
+			return true
+		}
+	}
+	return false
+}
+
+// writeJSON encodes v as JSON. The datasource unmarshals into pkg/schemas
+// structs, so reusing those structs keeps field names in lockstep.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func handleInfo(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, schemas.HistorianInfo{Version: "8.2.0", APIVersion: "1.0"})
+}
+
+func handleCollectors(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, []schemas.Collector{collector})
+}
+
+func handleTimeseriesDatabases(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	keyword := q.Get("Keyword")
+	result := []schemas.TimeseriesDatabase{}
+	for _, db := range []schemas.TimeseriesDatabase{database} {
+		if matchKeyword(keyword, db.UUID, db.Name) {
+			result = append(result, db)
+		}
+	}
+	writeJSON(w, result)
+}
+
+func handleMeasurements(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	keyword := q.Get("Keyword")
+	databaseUUIDs := param(q, "DatabaseUUIDs")
+	limit := paramInt(q, "Limit")
+	if limit == 0 {
+		limit = paramInt(q, "limit")
+	}
+
+	result := []schemas.Measurement{}
+	for i := range measurements {
+		if !matchKeyword(keyword, measurements[i].UUID, measurements[i].Name) {
+			continue
+		}
+		if len(databaseUUIDs) > 0 && !containsUUID(databaseUUIDs, measurements[i].DatabaseUUID) {
+			continue
+		}
+		result = append(result, measurements[i])
+	}
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
+	}
+	writeJSON(w, result)
+}
+
+func handleMeasurementByUUID(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("uuid"))
+	if err != nil {
+		http.Error(w, "invalid uuid", http.StatusBadRequest)
+		return
+	}
+	measurement, ok := measurementByUUID(id)
+	if !ok {
+		http.Error(w, "measurement not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, measurement)
+}
+
+// handleAssets implements the filters used by the datasource across historian
+// versions: UUIDs / Path (>=8.1 filtered asset resolution), Keyword (search),
+// ParentUUIDs (>=8.2 lazy tree loading, nil UUID = root level) and the
+// Include* flags that control whether the lazy-load hint fields are present.
+func handleAssets(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	keyword := q.Get("Keyword")
+	path := q.Get("Path")
+	uuids := param(q, "UUIDs")
+	parentUUIDs := param(q, "ParentUUIDs")
+	includeHasChildren := paramBool(q, "IncludeHasChildren")
+	includeHasAssetProperties := paramBool(q, "IncludeHasAssetProperties")
+
+	result := []schemas.Asset{}
+	allAssets := assets()
+	for i := range allAssets {
+		asset := allAssets[i]
+		if !matchKeyword(keyword, asset.UUID, asset.Name, asset.AssetPath) {
+			continue
+		}
+		if path != "" && !matchPath(path, asset.AssetPath) {
+			continue
+		}
+		if len(uuids) > 0 && !containsUUID(uuids, asset.UUID) {
+			continue
+		}
+		if len(parentUUIDs) > 0 {
+			parent := uuid.Nil
+			if asset.ParentUUID != nil {
+				parent = *asset.ParentUUID
+			}
+			if !containsUUID(parentUUIDs, parent) {
+				continue
+			}
+		}
+		if !includeHasChildren {
+			asset.HasChildren = nil
+		}
+		if !includeHasAssetProperties {
+			asset.HasAssetProperties = nil
+		}
+		result = append(result, asset)
+	}
+	writeJSON(w, result)
+}
+
+func handleAssetProperties(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	assetUUIDs := param(q, "AssetUUIDs")
+
+	result := []schemas.AssetProperty{}
+	for _, property := range assetProperties {
+		if len(assetUUIDs) > 0 && !containsUUID(assetUUIDs, property.AssetUUID) {
+			continue
+		}
+		result = append(result, property)
+	}
+	writeJSON(w, result)
+}
+
+func handleEventTypes(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	keyword := q.Get("Keyword")
+	uuids := param(q, "UUIDs")
+
+	result := []schemas.EventType{}
+	for _, eventType := range eventTypes {
+		if !matchKeyword(keyword, eventType.UUID, eventType.Name) {
+			continue
+		}
+		if len(uuids) > 0 && !containsUUID(uuids, eventType.UUID) {
+			continue
+		}
+		result = append(result, eventType)
+	}
+	writeJSON(w, result)
+}
+
+func handleEventTypeProperties(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	eventTypeUUIDs := param(q, "EventTypeUUIDs")
+	types := param(q, "Types")
+
+	result := []schemas.EventTypeProperty{}
+	for _, property := range eventTypeProperties {
+		if len(eventTypeUUIDs) > 0 && !containsUUID(eventTypeUUIDs, property.EventTypeUUID) {
+			continue
+		}
+		if len(types) > 0 && !slices.Contains(types, string(property.Type)) {
+			continue
+		}
+		result = append(result, property)
+	}
+	writeJSON(w, result)
+}
+
+func handleEventConfigurations(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, eventConfigurations)
+}

--- a/tests/mockhistorian/main.go
+++ b/tests/mockhistorian/main.go
@@ -1,50 +1,24 @@
-// Command mockhistorian is a minimal fake Factry Historian REST API used by the
-// Playwright e2e suite. It serves only the endpoints the datasource backend
-// calls during the health check and a Measurements query, returning
-// deterministic fixtures. Timeseries data is returned as protobuf-wrapped Arrow
-// frames, matching the real API contract that pkg/api/query.go decodes.
+// Command mockhistorian is a fake Factry Historian REST API used by the
+// Playwright e2e suite. It serves the endpoints the datasource backend calls
+// (health check, metadata, timeseries, events), returning deterministic
+// fixtures. Timeseries data is returned as protobuf-wrapped Arrow frames,
+// matching the real API contract that pkg/api/query.go decodes; JSON payloads
+// reuse pkg/schemas so field names stay in lockstep with the code under test.
+//
+// Fixtures live in fixtures.go, the JSON metadata handlers in handlers.go, the
+// Arrow/protobuf handlers in timeseries.go and the event handlers in events.go.
 package main
 
 import (
-	"encoding/json"
 	"log"
-	"math"
 	"net/http"
 	"strconv"
 	"time"
-
-	arrow_pb "github.com/factrylabs/factry-historian-datasource.git/pkg/proto"
-	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
-	"github.com/google/uuid"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"google.golang.org/protobuf/proto"
 )
 
 // listenAddr is the address the datasource points at via the e2e provisioning
 // (http://mockhistorian:8000).
 const listenAddr = ":8000"
-
-// Fixtures returned by the metadata endpoints. UUIDs are fixed so tests can
-// assert against them if needed.
-var (
-	databaseUUID    = uuid.MustParse("11111111-1111-1111-1111-111111111111")
-	measurementUUID = uuid.MustParse("22222222-2222-2222-2222-222222222222")
-
-	database = schemas.TimeseriesDatabase{
-		BaseModel:              schemas.BaseModel{UUID: databaseUUID, Name: "historian"},
-		TimeseriesDatabaseType: &schemas.TimeseriesDatabaseType{Name: "QuestDB"},
-		Description:            "Mock timeseries database for e2e tests",
-	}
-
-	measurement = schemas.Measurement{
-		BaseModel:    schemas.BaseModel{UUID: measurementUUID, Name: "e2e.motor.speed"},
-		Database:     &database,
-		DatabaseUUID: databaseUUID,
-		Datatype:     "float64",
-		Status:       "Good",
-		Description:  "Mock measurement for e2e tests",
-	}
-)
 
 func main() {
 	server := &http.Server{
@@ -76,87 +50,28 @@ func logRequests(next http.Handler) http.Handler {
 // handlers without binding a socket.
 func newMux() *http.ServeMux {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/timeseries-databases", writeJSON([]schemas.TimeseriesDatabase{database}))
-	mux.HandleFunc("GET /api/info", writeJSON(schemas.HistorianInfo{Version: "8.2.0", APIVersion: "1.0"}))
-	mux.HandleFunc("GET /api/measurements", writeJSON([]schemas.Measurement{measurement}))
+	mux.HandleFunc("GET /api/info", handleInfo)
+	mux.HandleFunc("GET /api/timeseries-databases", handleTimeseriesDatabases)
+	mux.HandleFunc("GET /api/collectors", handleCollectors)
+	mux.HandleFunc("GET /api/measurements", handleMeasurements)
+	mux.HandleFunc("GET /api/measurements/{uuid}", handleMeasurementByUUID)
+	mux.HandleFunc("GET /api/assets", handleAssets)
+	mux.HandleFunc("GET /api/asset-properties", handleAssetProperties)
+	mux.HandleFunc("GET /api/event-types", handleEventTypes)
+	mux.HandleFunc("GET /api/event-type-properties", handleEventTypeProperties)
+	mux.HandleFunc("GET /api/event-type-properties/{uuid}/values", handleEventPropertyValues)
+	mux.HandleFunc("GET /api/event-configurations", handleEventConfigurations)
+	mux.HandleFunc("GET /api/events", handleEvents)
 	mux.HandleFunc("POST /api/timeseries/query", handleTimeseriesQuery)
+	mux.HandleFunc("POST /api/timeseries/{uuid}/raw-query", handleRawQuery)
+	mux.HandleFunc("GET /api/timeseries/measurements/{uuid}/tags", handleTagKeys)
+	mux.HandleFunc("GET /api/timeseries/measurements/{uuid}/tags/{tagKey}", handleTagValues)
 	mux.HandleFunc("/", handleFallback)
 	return mux
 }
 
-// writeJSON returns a handler that encodes a fixed value as JSON. The datasource
-// unmarshals into pkg/schemas structs, so reusing those structs here keeps the
-// field names (PascalCase) in lockstep with the code under test.
-func writeJSON(v any) http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(v); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	}
-}
-
-// handleTimeseriesQuery answers POST /api/timeseries/query with a single Arrow
-// frame (time column + float64 value column) wrapped in a protobuf
-// arrow_pb.DataResponse, exactly what pkg/api/query.go expects to unmarshal.
-// Points are spread across the requested [Start, End] range so they always fall
-// inside the panel's time window.
-func handleTimeseriesQuery(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
-
-	query := schemas.Query{}
-	if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	frameBytes, err := buildFrame(query).MarshalArrow()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	out, err := proto.Marshal(&arrow_pb.DataResponse{Frames: [][]byte{frameBytes}})
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/protobuf")
-	if _, err := w.Write(out); err != nil {
-		log.Printf("write query response: %v", err)
-	}
-}
-
-// buildFrame produces a deterministic sine-wave series spanning the query range.
-func buildFrame(query schemas.Query) *data.Frame {
-	const points = 10
-
-	start := query.Start
-	end := time.Now()
-	if query.End != nil {
-		end = *query.End
-	}
-	if !end.After(start) {
-		end = start.Add(time.Hour)
-	}
-	step := end.Sub(start) / time.Duration(points)
-
-	times := make([]time.Time, points)
-	values := make([]float64, points)
-	for i := range points {
-		times[i] = start.Add(step * time.Duration(i))
-		values[i] = 20 + 5*math.Sin(float64(i))
-	}
-
-	return data.NewFrame(measurement.Name,
-		data.NewField("time", nil, times),
-		data.NewField(measurement.Name, nil, values),
-	)
-}
-
-// handleFallback keeps the plugin UI from erroring on resource calls this mock
-// does not implement (assets, events, tags, ...) by returning an empty array.
+// handleFallback keeps the plugin UI from erroring on calls this mock does not
+// implement by returning an empty array.
 func handleFallback(w http.ResponseWriter, r *http.Request) {
 	log.Printf("unhandled %s %s -> empty array", strconv.Quote(r.Method), strconv.Quote(r.URL.Path))
 	w.Header().Set("Content-Type", "application/json")

--- a/tests/mockhistorian/main_test.go
+++ b/tests/mockhistorian/main_test.go
@@ -378,7 +378,8 @@ func doRequest(t *testing.T, method, target, body string) *httptest.ResponseReco
 	if body != "" {
 		reader = strings.NewReader(body)
 	}
-	req := httptest.NewRequest(method, target, reader)
+	// t.Context() ties the request to the test's lifetime and satisfies noctx.
+	req := httptest.NewRequestWithContext(t.Context(), method, target, reader)
 	rec := httptest.NewRecorder()
 	newMux().ServeHTTP(rec, req)
 	return rec

--- a/tests/mockhistorian/main_test.go
+++ b/tests/mockhistorian/main_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -30,17 +32,211 @@ func TestTimeseriesDatabasesFixture(t *testing.T) {
 	assert.Equal(t, databaseUUID, got[0].UUID)
 }
 
-func TestMeasurementsFixture(t *testing.T) {
+func TestMeasurementsFilters(t *testing.T) {
 	t.Parallel()
 
-	rec := doRequest(t, http.MethodGet, "/api/measurements?Keyword=e2e.motor.speed", "")
+	tests := []struct {
+		query string
+		names []string
+	}{
+		{"", []string{"e2e.motor.speed", "e2e.motor.temperature"}},
+		{"?Keyword=e2e.motor.speed", []string{"e2e.motor.speed"}},
+		{"?Keyword=" + speedMeasurementUUID.String(), []string{"e2e.motor.speed"}},
+		{"?Keyword=/temp.*/", []string{"e2e.motor.temperature"}},
+		{"?Keyword=nomatch", nil},
+		{"?DatabaseUUIDs=" + databaseUUID.String(), []string{"e2e.motor.speed", "e2e.motor.temperature"}},
+		{"?DatabaseUUIDs[0]=" + motorAssetUUID.String(), nil},
+		{"?Limit=1", []string{"e2e.motor.speed"}},
+	}
+
+	for _, tc := range tests {
+		rec := doRequest(t, http.MethodGet, "/api/measurements"+tc.query, "")
+		require.Equal(t, http.StatusOK, rec.Code, tc.query)
+
+		var got []schemas.Measurement
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got), tc.query)
+		names := make([]string, 0, len(got))
+		for _, m := range got {
+			names = append(names, m.Name)
+		}
+		assert.ElementsMatch(t, tc.names, names, tc.query)
+	}
+}
+
+func TestMeasurementByUUID(t *testing.T) {
+	t.Parallel()
+
+	rec := doRequest(t, http.MethodGet, "/api/measurements/"+speedMeasurementUUID.String(), "")
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	var got []schemas.Measurement
+	var got schemas.Measurement
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "e2e.motor.speed", got.Name)
+
+	rec = doRequest(t, http.MethodGet, "/api/measurements/"+eventConfigurationUUID.String(), "")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestAssetsLazyTreeQueries(t *testing.T) {
+	t.Parallel()
+
+	// Root level query as sent by the frontend cascader (nil parent UUID).
+	rec := doRequest(t, http.MethodGet, "/api/assets?ParentUUIDs=00000000-0000-0000-0000-000000000000&IncludeHasChildren=true", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var roots []schemas.Asset
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &roots))
+	require.Len(t, roots, 1)
+	assert.Equal(t, "Site", roots[0].Name)
+	require.NotNil(t, roots[0].HasChildren)
+	assert.True(t, *roots[0].HasChildren)
+	// IncludeHasAssetProperties was not requested, so the field must be absent.
+	assert.Nil(t, roots[0].HasAssetProperties)
+
+	// Child level query.
+	rec = doRequest(t, http.MethodGet, "/api/assets?ParentUUIDs="+lineAssetUUID.String()+"&IncludeHasAssetProperties=true", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var children []schemas.Asset
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &children))
+	require.Len(t, children, 1)
+	assert.Equal(t, "Motor", children[0].Name)
+	require.NotNil(t, children[0].HasAssetProperties)
+	assert.True(t, *children[0].HasAssetProperties)
+}
+
+func TestAssetsFilteredResolution(t *testing.T) {
+	t.Parallel()
+
+	// UUIDs[i] form used by GetFilteredAssets on historian >= 8.1.
+	rec := doRequest(t, http.MethodGet, "/api/assets?UUIDs[0]="+motorAssetUUID.String(), "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var byUUID []schemas.Asset
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &byUUID))
+	require.Len(t, byUUID, 1)
+	assert.Equal(t, "Motor", byUUID[0].Name)
+
+	// Path form (exact match).
+	rec = doRequest(t, http.MethodGet, "/api/assets?Path="+url.QueryEscape(`Site\\Line 1\\Motor`), "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var byPath []schemas.Asset
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &byPath))
+	require.Len(t, byPath, 1)
+	assert.Equal(t, "Motor", byPath[0].Name)
+
+	// Keyword search used by the cascader's async search.
+	rec = doRequest(t, http.MethodGet, "/api/assets?Keyword=mot", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var byKeyword []schemas.Asset
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &byKeyword))
+	require.Len(t, byKeyword, 1)
+	assert.Equal(t, "Motor", byKeyword[0].Name)
+}
+
+func TestAssetProperties(t *testing.T) {
+	t.Parallel()
+
+	rec := doRequest(t, http.MethodGet, "/api/asset-properties?AssetUUIDs="+motorAssetUUID.String(), "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []schemas.AssetProperty
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 2)
+
+	rec = doRequest(t, http.MethodGet, "/api/asset-properties?AssetUUIDs[0]="+siteAssetUUID.String(), "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Empty(t, got)
+}
+
+func TestEventTypesKeywordAcceptsUUID(t *testing.T) {
+	t.Parallel()
+
+	// GetFilteredEventTypes passes the selected UUID as Keyword.
+	rec := doRequest(t, http.MethodGet, "/api/event-types?Keyword="+batchEventTypeUUID.String(), "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []schemas.EventType
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Len(t, got, 1)
-	assert.Equal(t, measurementUUID, got[0].UUID)
-	assert.Equal(t, databaseUUID, got[0].DatabaseUUID)
+	assert.Equal(t, "Batch", got[0].Name)
+}
+
+func TestEventTypeProperties(t *testing.T) {
+	t.Parallel()
+
+	rec := doRequest(t, http.MethodGet, "/api/event-type-properties?EventTypeUUIDs[0]="+batchEventTypeUUID.String()+"&Types[0]=simple", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []schemas.EventTypeProperty
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Len(t, got, 3)
+
+	rec = doRequest(t, http.MethodGet, "/api/event-type-properties?Types[0]=periodic", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Empty(t, got)
+}
+
+func TestEventsFilteredByWindowAssetAndStatus(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(6 * time.Hour)
+	window := fmt.Sprintf("StartTime=%s&StopTime=%s", start.Format(time.RFC3339), end.Format(time.RFC3339))
+
+	rec := doRequest(t, http.MethodGet, "/api/events?"+window+"&AssetUUIDs[0]="+motorAssetUUID.String()+"&EventTypeUUIDs[0]="+batchEventTypeUUID.String(), "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []schemas.Event
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 3)
+
+	// Default ordering is descending by start time; every event within window.
+	assert.True(t, got[0].StartTime.After(got[1].StartTime))
+	for _, event := range got {
+		assert.False(t, event.StartTime.Before(start))
+		assert.False(t, event.StartTime.After(end))
+		require.NotNil(t, event.Properties)
+	}
+
+	// The open event has no stop time.
+	assert.Nil(t, got[0].StopTime)
+	assert.Equal(t, schemas.EventStatusOpen, got[0].Status)
+
+	// Asset filter mismatch yields nothing.
+	rec = doRequest(t, http.MethodGet, "/api/events?"+window+"&AssetUUIDs[0]="+siteAssetUUID.String(), "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Empty(t, got)
+
+	// Status filter.
+	rec = doRequest(t, http.MethodGet, "/api/events?"+window+"&Status[0]=processed", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Len(t, got, 2)
+
+	// Ascending + limit.
+	rec = doRequest(t, http.MethodGet, "/api/events?"+window+"&Ascending=true&Limit=1", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "batch-41", got[0].Properties.Properties.GetString("code"))
+}
+
+func TestEventsPropertyFilter(t *testing.T) {
+	t.Parallel()
+
+	rec := doRequest(t, http.MethodGet, "/api/events?PropertyFilter[0].Property=code&PropertyFilter[0].Operator=%3D&PropertyFilter[0].Value=batch-42", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []schemas.Event
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "batch-42", got[0].Properties.Properties.GetString("code"))
+}
+
+func TestEventPropertyValues(t *testing.T) {
+	t.Parallel()
+
+	rec := doRequest(t, http.MethodGet, "/api/event-type-properties/"+codePropertyUUID.String()+"/values", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.ElementsMatch(t, []any{"batch-41", "batch-42", "batch-43"}, got)
 }
 
 // TestTimeseriesQueryDecodesLikeBackend proves the query response is
@@ -52,46 +248,127 @@ func TestTimeseriesQueryDecodesLikeBackend(t *testing.T) {
 	start := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	end := start.Add(time.Hour)
 	body := schemas.Query{
-		MeasurementUUIDs: []string{measurementUUID.String()},
+		MeasurementUUIDs: []string{speedMeasurementUUID.String(), temperatureMeasurementUUID.String()},
 		Start:            start,
 		End:              &end,
 	}
 	raw, err := json.Marshal(body)
 	require.NoError(t, err)
 
-	rec := doRequest(t, http.MethodPost, "/api/timeseries/query", string(raw))
-	require.Equal(t, http.StatusOK, rec.Code)
+	frames := decodeFrames(t, doRequest(t, http.MethodPost, "/api/timeseries/query", string(raw)))
+	require.Len(t, frames, 2)
 
+	for i, frame := range frames {
+		require.Len(t, frame.Fields, 2)
+
+		timeField, timeIdx := frame.FieldByName("time")
+		require.NotEqual(t, -1, timeIdx)
+		valueField, valueIdx := frame.FieldByName("value")
+		require.NotEqual(t, -1, valueIdx)
+		assert.Positive(t, timeField.Len())
+		assert.Equal(t, timeField.Len(), valueField.Len())
+
+		// The backend reads these to name frames and match asset properties.
+		require.NotNil(t, frame.Meta)
+		custom, ok := frame.Meta.Custom.(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, body.MeasurementUUIDs[i], custom["MeasurementUUID"])
+		assert.NotEmpty(t, custom["MeasurementName"])
+
+		// Every timestamp must sit inside the requested range so points render.
+		for j := 0; j < timeField.Len(); j++ {
+			ts, ok := timeField.At(j).(time.Time)
+			require.True(t, ok)
+			assert.False(t, ts.Before(start))
+			assert.False(t, ts.After(end))
+		}
+	}
+}
+
+func TestTimeseriesQueryByName(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Hour)
+	body := schemas.Query{
+		Measurements: []schemas.MeasurementByName{{Database: "historian", Measurement: "e2e.motor.speed"}},
+		Start:        start,
+		End:          &end,
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	frames := decodeFrames(t, doRequest(t, http.MethodPost, "/api/timeseries/query", string(raw)))
+	require.Len(t, frames, 1)
+	assert.Equal(t, "e2e.motor.speed", frames[0].Name)
+}
+
+func TestRawQuery(t *testing.T) {
+	t.Parallel()
+
+	body := `{"Query": "SELECT * FROM speed", "Format": "arrow"}`
+	frames := decodeFrames(t, doRequest(t, http.MethodPost, "/api/timeseries/"+databaseUUID.String()+"/raw-query", body))
+	require.Len(t, frames, 1)
+
+	labelField, idx := frames[0].FieldByName("label")
+	require.NotEqual(t, -1, idx)
+	assert.Equal(t, "raw-row-1", labelField.At(0))
+
+	rec := doRequest(t, http.MethodPost, "/api/timeseries/"+databaseUUID.String()+"/raw-query", `{"Query": ""}`)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestTagKeysAndValues(t *testing.T) {
+	t.Parallel()
+
+	frames := decodeFrames(t, doRequest(t, http.MethodGet, "/api/timeseries/measurements/"+speedMeasurementUUID.String()+"/tags", ""))
+	require.Len(t, frames, 1)
+	keys := stringsFromField(t, frames[0], "tagKey")
+	assert.ElementsMatch(t, []string{"location", "unit"}, keys)
+
+	frames = decodeFrames(t, doRequest(t, http.MethodGet, "/api/timeseries/measurements/"+speedMeasurementUUID.String()+"/tags/location", ""))
+	require.Len(t, frames, 1)
+	values := stringsFromField(t, frames[0], "value")
+	assert.ElementsMatch(t, []string{"ghent", "aalst"}, values)
+}
+
+func TestFallbackReturnsEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	rec := doRequest(t, http.MethodGet, "/api/not-implemented", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, "[]", rec.Body.String())
+}
+
+// stringsFromField extracts nullable strings the same way the backend's
+// getStringSetFromFrames does (values must decode as *string).
+func stringsFromField(t *testing.T, frame *data.Frame, fieldName string) []string {
+	t.Helper()
+
+	field, idx := frame.FieldByName(fieldName)
+	require.NotEqual(t, -1, idx, "field %s missing", fieldName)
+
+	result := []string{}
+	for i := 0; i < field.Len(); i++ {
+		value, ok := field.At(i).(*string)
+		require.True(t, ok, "field %s must decode as *string", fieldName)
+		require.NotNil(t, value)
+		result = append(result, *value)
+	}
+	return result
+}
+
+func decodeFrames(t *testing.T, rec *httptest.ResponseRecorder) data.Frames {
+	t.Helper()
+
+	require.Equal(t, http.StatusOK, rec.Code)
 	dataResponse := arrow_pb.DataResponse{}
 	require.NoError(t, proto.Unmarshal(rec.Body.Bytes(), &dataResponse))
 	require.Empty(t, dataResponse.GetError())
 
 	frames, err := data.UnmarshalArrowFrames(dataResponse.GetFrames())
 	require.NoError(t, err)
-	require.Len(t, frames, 1)
-	require.Len(t, frames[0].Fields, 2)
-
-	timeField := frames[0].Fields[0]
-	valueField := frames[0].Fields[1]
-	assert.Equal(t, "time", timeField.Name)
-	assert.Positive(t, timeField.Len())
-	assert.Equal(t, timeField.Len(), valueField.Len())
-
-	// Every timestamp must sit inside the requested range so points render.
-	for i := 0; i < timeField.Len(); i++ {
-		ts, ok := timeField.At(i).(time.Time)
-		require.True(t, ok)
-		assert.False(t, ts.Before(start))
-		assert.False(t, ts.After(end))
-	}
-}
-
-func TestFallbackReturnsEmptyArray(t *testing.T) {
-	t.Parallel()
-
-	rec := doRequest(t, http.MethodGet, "/api/assets", "")
-	require.Equal(t, http.StatusOK, rec.Code)
-	assert.JSONEq(t, "[]", rec.Body.String())
+	return frames
 }
 
 func doRequest(t *testing.T, method, target, body string) *httptest.ResponseRecorder {
@@ -101,7 +378,7 @@ func doRequest(t *testing.T, method, target, body string) *httptest.ResponseReco
 	if body != "" {
 		reader = strings.NewReader(body)
 	}
-	req := httptest.NewRequestWithContext(t.Context(), method, target, reader)
+	req := httptest.NewRequest(method, target, reader)
 	rec := httptest.NewRecorder()
 	newMux().ServeHTTP(rec, req)
 	return rec

--- a/tests/mockhistorian/timeseries.go
+++ b/tests/mockhistorian/timeseries.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"math"
+	"net/http"
+	"time"
+
+	arrow_pb "github.com/factrylabs/factry-historian-datasource.git/pkg/proto"
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"google.golang.org/protobuf/proto"
+)
+
+// writeFrames marshals frames to Arrow and wraps them in the protobuf
+// DataResponse, exactly what pkg/api/query.go expects to unmarshal.
+func writeFrames(w http.ResponseWriter, frames data.Frames) {
+	frameBytes := make([][]byte, 0, len(frames))
+	for _, frame := range frames {
+		b, err := frame.MarshalArrow()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		frameBytes = append(frameBytes, b)
+	}
+
+	out, err := proto.Marshal(&arrow_pb.DataResponse{Frames: frameBytes})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/protobuf")
+	if _, err := w.Write(out); err != nil {
+		log.Printf("write query response: %v", err)
+	}
+}
+
+// handleTimeseriesQuery answers POST /api/timeseries/query with one Arrow
+// frame per requested measurement, carrying the same Meta.Custom keys the
+// real historian sets (MeasurementUUID etc.), which the backend uses to name
+// frames and resolve asset properties.
+func handleTimeseriesQuery(w http.ResponseWriter, r *http.Request) {
+	defer func() { _ = r.Body.Close() }()
+
+	query := schemas.Query{}
+	if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	requested := []schemas.Measurement{}
+	for _, raw := range query.MeasurementUUIDs {
+		if id, err := uuid.Parse(raw); err == nil {
+			if measurement, ok := measurementByUUID(id); ok {
+				requested = append(requested, measurement)
+			}
+		}
+	}
+	for _, byName := range query.Measurements {
+		for i := range measurements {
+			if measurements[i].Name == byName.Measurement {
+				requested = append(requested, measurements[i])
+			}
+		}
+	}
+
+	frames := make(data.Frames, 0, len(requested))
+	for i := range requested {
+		frames = append(frames, buildFrame(query, requested[i], float64(i)))
+	}
+	writeFrames(w, frames)
+}
+
+// buildFrame produces a deterministic sine-wave series spanning the query
+// range. The offset separates the series of different measurements so tests
+// can tell them apart.
+func buildFrame(query schemas.Query, measurement schemas.Measurement, offset float64) *data.Frame {
+	const points = 10
+
+	start := query.Start
+	end := time.Now()
+	if query.End != nil {
+		end = *query.End
+	}
+	if !end.After(start) {
+		end = start.Add(time.Hour)
+	}
+	step := end.Sub(start) / time.Duration(points)
+
+	times := make([]time.Time, points)
+	values := make([]float64, points)
+	for i := range points {
+		times[i] = start.Add(step * time.Duration(i))
+		values[i] = 20 + 10*offset + 5*math.Sin(float64(i))
+	}
+
+	frame := data.NewFrame(measurement.Name,
+		data.NewField("time", nil, times),
+		data.NewField("value", nil, values),
+	)
+	frame.Meta = &data.FrameMeta{
+		Custom: map[string]interface{}{
+			"MeasurementUUID": measurement.UUID.String(),
+			"MeasurementName": measurement.Name,
+			"DatabaseUUID":    measurement.DatabaseUUID.String(),
+			"DatabaseName":    database.Name,
+			"Description":     measurement.Description,
+			"Labels":          map[string]interface{}{"status": "Good"},
+		},
+	}
+	return frame
+}
+
+// handleRawQuery answers POST /api/timeseries/{uuid}/raw-query with a fixed
+// table-shaped frame, enough for the Raw query editor to render rows.
+func handleRawQuery(w http.ResponseWriter, r *http.Request) {
+	defer func() { _ = r.Body.Close() }()
+
+	if _, err := uuid.Parse(r.PathValue("uuid")); err != nil {
+		http.Error(w, "invalid database uuid", http.StatusBadRequest)
+		return
+	}
+
+	query := schemas.RawQuery{}
+	if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if query.Query == "" {
+		http.Error(w, "empty query", http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now().UTC().Truncate(time.Minute)
+	frame := data.NewFrame("",
+		data.NewField("time", nil, []time.Time{now.Add(-2 * time.Minute), now.Add(-time.Minute), now}),
+		data.NewField("raw_value", nil, []float64{1, 2, 3}),
+		data.NewField("label", nil, []string{"raw-row-1", "raw-row-2", "raw-row-3"}),
+	)
+	writeFrames(w, data.Frames{frame})
+}
+
+// handleTagKeys answers GET /api/timeseries/measurements/{uuid}/tags. The
+// backend extracts nullable strings from the "tagKey" column.
+func handleTagKeys(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("uuid"))
+	if err != nil {
+		http.Error(w, "invalid uuid", http.StatusBadRequest)
+		return
+	}
+
+	keys := []*string{}
+	for key := range tagsPerMeasurement[id] {
+		k := key
+		keys = append(keys, &k)
+	}
+	frame := data.NewFrame("tags", data.NewField("tagKey", nil, keys))
+	writeFrames(w, data.Frames{frame})
+}
+
+// handleTagValues answers GET /api/timeseries/measurements/{uuid}/tags/{key}.
+// The backend extracts nullable strings from the "value" column.
+func handleTagValues(w http.ResponseWriter, r *http.Request) {
+	id, err := uuid.Parse(r.PathValue("uuid"))
+	if err != nil {
+		http.Error(w, "invalid uuid", http.StatusBadRequest)
+		return
+	}
+
+	values := []*string{}
+	for _, value := range tagsPerMeasurement[id][r.PathValue("tagKey")] {
+		v := value
+		values = append(values, &v)
+	}
+	frame := data.NewFrame("tagValues", data.NewField("value", nil, values))
+	writeFrames(w, data.Frames{frame})
+}

--- a/tests/provisioning/dashboards/assets.json
+++ b/tests/provisioning/dashboards/assets.json
@@ -1,0 +1,42 @@
+{
+  "uid": "e2e-assets",
+  "title": "E2E Assets",
+  "tags": ["e2e"],
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "table",
+      "title": "Motor properties",
+      "datasource": { "type": "factry-historian-datasource", "uid": "factry-historian-e2e" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "factry-historian-datasource", "uid": "factry-historian-e2e" },
+          "queryType": "AssetMeasurementQuery",
+          "tabIndex": 0,
+          "seriesLimit": 50,
+          "query": {
+            "Assets": ["66666666-6666-6666-6666-666666666666"],
+            "AssetProperties": ["Speed", "Temperature"],
+            "Options": {
+              "Aggregation": { "Name": "mean", "Period": "$__interval" },
+              "GroupBy": [],
+              "Tags": {},
+              "IncludeLastKnownPoint": false,
+              "FillInitialEmptyValues": false,
+              "UseEngineeringSpecs": false,
+              "MetadataAsLabels": false,
+              "DisplayDatabaseName": false,
+              "DisplayDescription": false
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/provisioning/dashboards/events.json
+++ b/tests/provisioning/dashboards/events.json
@@ -1,0 +1,41 @@
+{
+  "uid": "e2e-events",
+  "title": "E2E Events",
+  "tags": ["e2e"],
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "table",
+      "title": "Batch events",
+      "datasource": { "type": "factry-historian-datasource", "uid": "factry-historian-e2e" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "factry-historian-datasource", "uid": "factry-historian-e2e" },
+          "queryType": "EventQuery",
+          "tabIndex": 2,
+          "seriesLimit": 50,
+          "query": {
+            "Type": "simple",
+            "Assets": ["66666666-6666-6666-6666-666666666666"],
+            "EventTypes": ["99999999-9999-9999-9999-999999999999"],
+            "Statuses": [],
+            "Properties": [],
+            "PropertyFilter": [],
+            "IncludeParentInfo": false,
+            "QueryAssetProperties": false,
+            "OverrideAssets": [],
+            "Limit": 1000,
+            "OverrideTimeRange": false,
+            "Ascending": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/provisioning/dashboards/raw.json
+++ b/tests/provisioning/dashboards/raw.json
@@ -1,0 +1,32 @@
+{
+  "uid": "e2e-raw",
+  "title": "E2E Raw Query",
+  "tags": ["e2e"],
+  "timezone": "utc",
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "table",
+      "title": "Raw rows",
+      "datasource": { "type": "factry-historian-datasource", "uid": "factry-historian-e2e" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "factry-historian-datasource", "uid": "factry-historian-e2e" },
+          "queryType": "RawQuery",
+          "tabIndex": 3,
+          "seriesLimit": 50,
+          "query": {
+            "TimeseriesDatabase": "11111111-1111-1111-1111-111111111111",
+            "Query": "SELECT time, value FROM \"e2e.motor.speed\" WHERE $timeFilter",
+            "Format": "arrow"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/rawQuery.spec.ts
+++ b/tests/rawQuery.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from './fixtures';
+import { inlineFieldInput } from './utils';
+
+test.describe('raw query', () => {
+  test('provisioned dashboard renders raw query rows', async ({
+    readProvisionedDashboard,
+    gotoDashboardPage,
+  }) => {
+    const dashboard = await readProvisionedDashboard({ fileName: 'raw.json' });
+    const dashboardPage = await gotoDashboardPage(dashboard);
+
+    // RawQuery end-to-end: the backend substitutes $timeFilter, POSTs to
+    // /api/timeseries/{db}/raw-query and decodes the Arrow response.
+    const panel = dashboardPage.getPanelByTitle('Raw rows');
+    await expect(panel.getErrorIcon()).toBeHidden();
+    await expect(panel.locator).toContainText('raw-row-1');
+    await expect(panel.locator).toContainText('raw-row-3');
+  });
+
+  test('selecting a database reveals the query editor', async ({
+    panelEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await panelEditPage.datasource.set(ds.name);
+
+    await page.getByRole('radio', { name: 'Raw' }).check({ force: true });
+
+    // The database select loads from the mock's /api/timeseries-databases.
+    // Click the combobox input; the placeholder text is not rendered as a
+    // matchable text node on every Grafana version.
+    await inlineFieldInput(page, 'Database').click();
+    await page.getByRole('option', { name: /historian/ }).click();
+
+    // The code editor only renders once a database is selected, labelled with
+    // the database type from the mock fixture (QuestDB).
+    await expect(page.getByText('QuestDB query')).toBeVisible();
+  });
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from './fixtures';
+import { inlineFieldInput } from './utils';
+
+// Cross-cutting smoke test: the query editor exposes all four query types and
+// switching tabs swaps in the matching editor surface. Deeper per-type flows
+// live in the *Query.spec.ts files.
+test.describe('query editor navigation', () => {
+  test('exposes the four query-type tabs and switches editors', async ({
+    panelEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await panelEditPage.datasource.set(ds.name);
+
+    for (const tab of ['Assets', 'Measurements', 'Events', 'Raw']) {
+      await expect(page.getByRole('radio', { name: tab })).toBeVisible();
+    }
+
+    // Assets is the default tab: asset cascader + properties select.
+    await expect(page.getByText('Properties', { exact: true })).toBeVisible();
+
+    await page.getByRole('radio', { name: 'Measurements' }).check({ force: true });
+    await expect(page.getByText('select measurement')).toBeVisible();
+    await expect(page.getByText('Use regular expression')).toBeVisible();
+
+    await page.getByRole('radio', { name: 'Events' }).check({ force: true });
+    await expect(page.getByText('Event query', { exact: true })).toBeVisible();
+    await expect(page.getByText('Query Type', { exact: true })).toBeVisible();
+
+    await page.getByRole('radio', { name: 'Raw' }).check({ force: true });
+    // The database select renders without a matchable placeholder text node on
+    // some Grafana versions, so assert on the labelled combobox input instead.
+    await expect(inlineFieldInput(page, 'Database')).toBeVisible();
+  });
+});

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,30 @@
+import type { Locator, Page } from '@playwright/test';
+
+// Grafana's InlineField renders `<div><label>…</label><child/></div>`, so the
+// first input inside the label's next sibling is the field's control. This is
+// stable across Grafana versions and avoids page-wide nth() indexes.
+export function inlineFieldInput(page: Page, label: string): Locator {
+  return page.locator(`label:has-text("${label}") + div input`).first();
+}
+
+// Renders the query result as a table in the panel editor. Uses the editor's
+// "Table view" toggle instead of panelEditPage.setVisualization('Table'):
+// Grafana >= 12.4 changed the visualization picker markup that plugin-e2e
+// 1.19 targets, while the toggle is stable across the version matrix.
+export async function enableTableView(page: Page): Promise<void> {
+  await page.getByTestId('data-testid toggle-table-view').check({ force: true });
+}
+
+// Walks the lazy-loading asset cascader one menu level at a time. Each click
+// triggers a child fetch from the mock (ParentUUIDs filter); Playwright
+// auto-waits for the next level to appear.
+export async function selectCascaderPath(page: Page, input: Locator, path: string[]): Promise<void> {
+  await input.click();
+  for (const segment of path) {
+    await page.locator('.rc-cascader-menu-item', { hasText: segment }).click();
+  }
+  // The dropdown's open state follows the input's focus, so it stays open
+  // after selecting and would intercept clicks on the next field. Blur it.
+  await page.keyboard.press('Tab');
+  await page.locator('.rc-cascader-menu-item').first().waitFor({ state: 'hidden' });
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -15,13 +15,27 @@ export async function enableTableView(page: Page): Promise<void> {
   await page.getByTestId('data-testid toggle-table-view').check({ force: true });
 }
 
+// Escapes a literal for use inside a RegExp. Asset and property names are data,
+// not patterns, so they must not be interpreted as one.
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 // Walks the lazy-loading asset cascader one menu level at a time. Each click
 // triggers a child fetch from the mock (ParentUUIDs filter); Playwright
 // auto-waits for the next level to appear.
+//
+// Matching is strict on purpose: anchored on the full label so "Line 1" cannot
+// select "Line 10", and scoped to the column belonging to this depth so a name
+// that also exists in an ancestor level cannot be picked instead. rc-cascader
+// renders one ul.rc-cascader-menu per open level, left to right. The 📦/📏
+// prefix on option labels is the only part callers do not spell out.
 export async function selectCascaderPath(page: Page, input: Locator, path: string[]): Promise<void> {
   await input.click();
-  for (const segment of path) {
-    await page.locator('.rc-cascader-menu-item', { hasText: segment }).click();
+  for (const [depth, segment] of path.entries()) {
+    const label = new RegExp(`^(?:📦 |📏 )?${escapeRegExp(segment)}$`);
+    const column = page.locator('.rc-cascader-menu').nth(depth);
+    await column.locator('.rc-cascader-menu-item').filter({ hasText: label }).click();
   }
   // The dropdown's open state follows the input's focus, so it stays open
   // after selecting and would intercept clicks on the next field. Blur it.

--- a/tests/variables.spec.ts
+++ b/tests/variables.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from './fixtures';
+
+// The custom variable editor drives the datasource's resource endpoints; each
+// query type must produce selectable options from the mock fixtures.
+test.describe('template variables', () => {
+  test('measurement variable lists measurements with their database', async ({
+    variableEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await variableEditPage.datasource.set(ds.name);
+
+    await page.getByLabel('Query type').click();
+    await page.getByRole('option', { name: 'Measurement', exact: true }).click();
+
+    await variableEditPage.runQuery();
+    await expect(variableEditPage).toDisplayPreviews([/e2e\.motor\.speed - historian/, /e2e\.motor\.temperature - historian/]);
+  });
+
+  test('database variable lists timeseries databases', async ({
+    variableEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await variableEditPage.datasource.set(ds.name);
+
+    await page.getByLabel('Query type').click();
+    await page.getByRole('option', { name: 'Database', exact: true }).click();
+
+    await variableEditPage.runQuery();
+    await expect(variableEditPage).toDisplayPreviews(['historian']);
+  });
+
+  test('asset variable lists the asset tree', async ({
+    variableEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await variableEditPage.datasource.set(ds.name);
+
+    await page.getByLabel('Query type').click();
+    await page.getByRole('option', { name: 'Asset', exact: true }).click();
+
+    await variableEditPage.runQuery();
+    await expect(variableEditPage).toDisplayPreviews(['Site', 'Line 1', 'Motor']);
+  });
+
+  test('event type variable lists event types', async ({
+    variableEditPage,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+    await variableEditPage.datasource.set(ds.name);
+
+    await page.getByLabel('Query type').click();
+    await page.getByRole('option', { name: 'Event type', exact: true }).click();
+
+    await variableEditPage.runQuery();
+    await expect(variableEditPage).toDisplayPreviews(['Batch']);
+  });
+});


### PR DESCRIPTION
Continues `test/add-e2e-testing` (rebased onto main): grows the Playwright suite from 3 tests to 18 across every editor surface, and adds e2e coverage reporting for both the TypeScript frontend and the Go backend.

## Mock Historian

The mock now serves a deterministic mini-plant instead of a single measurement:

- Database `historian`, measurements `e2e.motor.speed` / `e2e.motor.temperature` with tags
- Asset tree `Site \\ Line 1 \\ Motor` with `Speed` / `Temperature` properties
- Event type `Batch` (simple properties `code`, `good`, `yield`) configured on Motor, three events generated relative to the queried window (one still open)
- Endpoints added: assets (lazy tree + UUID/Path/Keyword resolution), asset properties, event types/properties/configurations, events (incl. property filters), event property values, tag keys/values, raw query

Query params are parsed in both encodings the plugin uses (repeated keys from the frontend resource client, `Key[0]` indexed form from the Go backend), and query-response frames now carry the `Meta.Custom` keys (`MeasurementUUID`, ...) the backend relies on for frame naming and asset-property resolution. Every endpoint has Go unit tests, including protobuf/Arrow round-trips through the exact decode path of `pkg/api/query.go`.

## New specs (18 tests)

- **config**: health check passes against the mock, fails against an unreachable URL
- **measurements**: provisioned dashboard, interactive measurement picking, regex mode
- **assets**: provisioned dashboard, cascader walk Site → Line 1 → Motor → Speed (lazy loading)
- **events**: provisioned dashboard renders all three batches, interactive asset + event type selection
- **raw**: provisioned dashboard renders rows, database select reveals the code editor
- **variables**: measurement / database / asset / event type previews
- **annotations**: event query built in the annotation editor returns OK
- **smoke**: tab navigation swaps editor surfaces

New provisioned dashboards `assets.json`, `events.json`, `raw.json` alongside the existing measurements one.

## Coverage reporting

- **Frontend**: every test collects Chromium V8 coverage (`tests/fixtures.ts`); `monocart-coverage-reports` maps it back to `src/` through the production source map. Console summary + HTML + lcov + json-summary under `coverage/e2e-frontend/`. Run locally with `pnpm e2e:coverage`.
- **Backend**: CI rebuilds the plugin binary with `go build -cover`; `pkg/coverageflush.go` flushes counters to `GOCOVERDIR` every 15s (guarded by the env var, dormant in production builds) because Grafana kills the plugin subprocess on shutdown, so write-at-exit never runs. `docker-compose.e2e.yaml` forwards `GOCOVERDIR` into the plugin process.
- `scripts/e2e-coverage-report.sh` renders both into the GitHub job summary per matrix leg and CI uploads `e2e-coverage-*` artifacts with the HTML reports.

Docs in `tests/README.md`.

## Verification

- `go test ./tests/mockhistorian ./pkg/...` green
- `pnpm typecheck`, `pnpm lint`, `pnpm test:ci` (176 tests) green
- `playwright test --list` resolves all 18 tests; mock exercised manually over HTTP
- Full browser run happens in this PR's CI matrix (no Docker in the dev environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4w5mfD1LprT3wifx7fDJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4w5mfD1LprT3wifx7fDJA)_