### PR TITLE
fix(events): resolve parent property datatype through template variables

### DIFF
--- a/src/QueryEditor/EventFilter.test.tsx
+++ b/src/QueryEditor/EventFilter.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { EventFilter } from './EventFilter'
+import { QueryTag } from 'components/TagsSection/TagsSection'
 import { DataSource } from 'datasource'
-import { EventQuery } from 'types'
+import { EventQuery, EventType, EventTypeProperty, PropertyDatatype, PropertyType } from 'types'
 
 jest.mock('@grafana/runtime', () => ({
   getTemplateSrv: () => ({ getVariables: () => [] }),
@@ -25,16 +26,20 @@ jest.mock('@grafana/ui', () => ({
 // on the label EventFilter passes down.
 jest.mock('components/Cascader/Cascader', () => ({
   __esModule: true,
-  default: ({ initialLabel }: { initialLabel: string }) => (
-    <input data-testid="assets" readOnly value={initialLabel} />
-  ),
+  default: ({ initialLabel }: { initialLabel: string }) => <input data-testid="assets" readOnly value={initialLabel} />,
 }))
 
+// TagsSection test double: keeps a handle on the onChange EventFilter passes
+// down so tests can drive the WHERE section without rendering the real editor.
+let mockTagsSectionOnChange: ((tags: QueryTag[]) => void) | undefined
 jest.mock('components/TagsSection/TagsSection', () => ({
-  TagsSection: () => null,
+  TagsSection: ({ onChange }: { onChange: (tags: QueryTag[]) => void }) => {
+    mockTagsSectionOnChange = onChange
+    return null
+  },
 }))
 
-const createMockDatasource = () =>
+const createMockDatasource = (overrides: Partial<Record<keyof DataSource, unknown>> = {}) =>
   ({
     getAssets: jest.fn().mockResolvedValue([]),
     getEventTypes: jest.fn().mockResolvedValue([]),
@@ -43,7 +48,8 @@ const createMockDatasource = () =>
     multiSelectReplace: (value: string) => [value],
     containsTemplate: () => false,
     historianInfo: { Version: '' },
-  }) as unknown as DataSource
+    ...overrides,
+  } as unknown as DataSource)
 
 const renderComponent = (assets: string[]) => {
   const query: EventQuery = {
@@ -72,5 +78,57 @@ describe('EventFilter', () => {
     await waitFor(() => {
       expect(screen.getByTestId('assets')).toHaveValue('$myVar')
     })
+  })
+
+  it('resolves the datatype of a parent property when the event types are a template variable', async () => {
+    const eventTypes: EventType[] = [
+      { Name: 'Batch', UUID: 'batch-uuid', Description: '' },
+      { Name: 'Phase', UUID: 'phase-uuid', Description: '', ParentUUID: 'batch-uuid' },
+    ]
+    const eventTypeProperties: EventTypeProperty[] = [
+      {
+        Name: 'Batch number',
+        UUID: 'prop-1',
+        EventTypeUUID: 'batch-uuid',
+        Datatype: PropertyDatatype.String,
+        Type: PropertyType.Simple,
+      },
+    ]
+    const datasource = createMockDatasource({
+      getEventTypes: jest.fn().mockResolvedValue(eventTypes),
+      getEventTypeProperties: jest.fn().mockResolvedValue(eventTypeProperties),
+      multiSelectReplace: (value: string) => (value === '$EventTypes' ? ['phase-uuid'] : [value]),
+      containsTemplate: (value: string) => value.startsWith('$'),
+    })
+    const onChangeQuery = jest.fn()
+    const query = {
+      Assets: [],
+      EventTypes: ['$EventTypes'],
+      Properties: [],
+      Statuses: [],
+      PropertyFilter: [],
+      IncludeParentInfo: true,
+    } as unknown as EventQuery
+
+    render(<EventFilter query={query} datasource={datasource} onChangeQuery={onChangeQuery} />)
+    await waitFor(() => {
+      expect(mockTagsSectionOnChange).toBeDefined()
+    })
+
+    act(() => {
+      mockTagsSectionOnChange!([{ key: 'parent:Batch number', value: '$BatchNumber', operator: 'IN', condition: '' }])
+    })
+
+    expect(onChangeQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        PropertyFilter: [
+          expect.objectContaining({
+            Property: 'parent:Batch number',
+            Datatype: PropertyDatatype.String,
+            Parent: true,
+          }),
+        ],
+      })
+    )
   })
 })

--- a/src/QueryEditor/EventFilter.test.tsx
+++ b/src/QueryEditor/EventFilter.test.tsx
@@ -29,12 +29,20 @@ jest.mock('components/Cascader/Cascader', () => ({
   default: ({ initialLabel }: { initialLabel: string }) => <input data-testid="assets" readOnly value={initialLabel} />,
 }))
 
-// TagsSection test double: keeps a handle on the onChange EventFilter passes
-// down so tests can drive the WHERE section without rendering the real editor.
+// TagsSection test double: keeps a handle on the props EventFilter passes down
+// so tests can drive the WHERE section without rendering the real editor.
 let mockTagsSectionOnChange: ((tags: QueryTag[]) => void) | undefined
+let mockTagsSectionGetTagKeyOptions: (() => Promise<string[]>) | undefined
 jest.mock('components/TagsSection/TagsSection', () => ({
-  TagsSection: ({ onChange }: { onChange: (tags: QueryTag[]) => void }) => {
+  TagsSection: ({
+    onChange,
+    getTagKeyOptions,
+  }: {
+    onChange: (tags: QueryTag[]) => void
+    getTagKeyOptions: () => Promise<string[]>
+  }) => {
     mockTagsSectionOnChange = onChange
+    mockTagsSectionGetTagKeyOptions = getTagKeyOptions
     return null
   },
 }))
@@ -130,5 +138,52 @@ describe('EventFilter', () => {
         ],
       })
     )
+  })
+
+  it('only offers parent keys that exist on the parent event type', async () => {
+    const eventTypes: EventType[] = [
+      { Name: 'Batch', UUID: 'batch-uuid', Description: '' },
+      { Name: 'Phase', UUID: 'phase-uuid', Description: '', ParentUUID: 'batch-uuid' },
+    ]
+    const simple = (name: string, uuid: string, eventTypeUUID: string): EventTypeProperty => ({
+      Name: name,
+      UUID: uuid,
+      EventTypeUUID: eventTypeUUID,
+      Datatype: PropertyDatatype.String,
+      Type: PropertyType.Simple,
+    })
+    const datasource = createMockDatasource({
+      getEventTypes: jest.fn().mockResolvedValue(eventTypes),
+      getEventTypeProperties: jest
+        .fn()
+        .mockResolvedValue([
+          simple('Batch number', 'prop-1', 'batch-uuid'),
+          simple('Phase step', 'prop-2', 'phase-uuid'),
+        ]),
+      multiSelectReplace: (value: string) => (value === '$EventTypes' ? ['phase-uuid'] : [value]),
+      containsTemplate: (value: string) => value.startsWith('$'),
+    })
+    const query = {
+      Assets: [],
+      EventTypes: ['$EventTypes'],
+      Properties: [],
+      Statuses: [],
+      PropertyFilter: [],
+      IncludeParentInfo: true,
+    } as unknown as EventQuery
+
+    render(<EventFilter query={query} datasource={datasource} onChangeQuery={jest.fn()} />)
+    await waitFor(() => {
+      expect(mockTagsSectionGetTagKeyOptions).toBeDefined()
+    })
+
+    const keys = await mockTagsSectionGetTagKeyOptions!()
+
+    expect(keys).toContain('Phase step')
+    expect(keys).toContain('parent:Batch number')
+    // 'Phase step' exists on the child only, so it is not a parent key, and
+    // 'Batch number' exists on the parent only, so it is not an own key.
+    expect(keys).not.toContain('parent:Phase step')
+    expect(keys).not.toContain('Batch number')
   })
 })

--- a/src/QueryEditor/EventFilter.tsx
+++ b/src/QueryEditor/EventFilter.tsx
@@ -26,8 +26,10 @@ import {
   isSupportedPropertyType,
   matchedAssets,
   NIL_UUID,
+  parentEventTypeUUIDs,
   propertyFilterToQueryTags,
   resolveAssetLabel,
+  resolvePropertyDatatype,
   resolveSelectedAssets,
   searchAssetsAndProperties,
   templateVariablesToCascaderOptions,
@@ -309,14 +311,8 @@ export const EventFilter = (props: Props): JSX.Element => {
     } else {
       selectedEventTypesUUIDs = getSelectedEventTypes(props.query.EventTypes ?? [])
     }
-    const datatype = eventTypeProperties
-      .filter((e) => selectedEventTypesUUIDs.includes(e.EventTypeUUID))
-      .find((e) => e.Name === property)?.Datatype
-    if (!datatype) {
-      return PropertyDatatype.Number
-    }
 
-    return datatype
+    return resolvePropertyDatatype(property, eventTypeProperties, selectedEventTypesUUIDs)
   }
 
   const getTagsKeyOptions = (eventTypes: string[]): string[] => {
@@ -388,10 +384,7 @@ export const EventFilter = (props: Props): JSX.Element => {
   }
 
   const getSelectedParentEventTypes = (eventTypeSelectors: string[]): string[] => {
-    const selectedEventTypes = eventTypes.filter((e) => eventTypeSelectors.some((et) => e.UUID === et))
-    const parentEventTypes = eventTypes.filter((e) => selectedEventTypes.some((et) => e.UUID === et.ParentUUID))
-    const parentEventTypeUUIDs = parentEventTypes.map((e) => e.UUID)
-    return parentEventTypeUUIDs
+    return parentEventTypeUUIDs(getSelectedEventTypes(eventTypeSelectors), eventTypes)
   }
 
   const availableProperties = (eventTypes: string[], includeParentInfo: boolean): Array<SelectableValue<string>> => {

--- a/src/QueryEditor/EventFilter.tsx
+++ b/src/QueryEditor/EventFilter.tsx
@@ -20,6 +20,7 @@ import {
 import { getValueFilterOperatorsForVersion, KnownOperator, needsValue } from 'util/eventFilter'
 import {
   buildLazyCascaderOptions,
+  eventTypeUUIDsForProperties,
   fetchLazyChildOptions,
   getChildAssets,
   isLazyLoadingEnabled,
@@ -330,40 +331,24 @@ export const EventFilter = (props: Props): JSX.Element => {
   }
 
   const availableSimpleProperties = (eventTypeSelectors: string[], onlyParentProperties = false): string[] => {
-    if (eventTypeSelectors.some((et) => props.datasource.containsTemplate(et))) {
-      return [...new Set(eventTypeProperties.filter((e) => e.Type === PropertyType.Simple).map((e) => e.Name))]
-    }
-    let selectedEventTypeUUIDs: string[] = []
-    if (onlyParentProperties) {
-      selectedEventTypeUUIDs = getSelectedParentEventTypes(eventTypeSelectors)
-    } else {
-      selectedEventTypeUUIDs = getSelectedEventTypes(eventTypeSelectors)
-    }
+    const eventTypeUUIDs = eventTypeUUIDsForProperties(
+      props.datasource,
+      eventTypeSelectors,
+      eventTypes,
+      onlyParentProperties
+    )
     return [
       ...new Set(
         eventTypeProperties
           .filter((e) => e.Type === PropertyType.Simple)
-          .filter((e) => selectedEventTypeUUIDs.includes(e.EventTypeUUID))
+          .filter((e) => eventTypeUUIDs.includes(e.EventTypeUUID))
           .map((e) => e.Name)
       ),
     ]
   }
 
   const availablePeriodicProperties = (eventTypeSelectors: string[]): string[] => {
-    if (eventTypeSelectors.some((et) => props.datasource.containsTemplate(et))) {
-      return [
-        ...new Set(
-          eventTypeProperties
-            .filter((e) =>
-              props.query.Type === PropertyType.Periodic
-                ? e.Type === PropertyType.PeriodicWithDimension || e.Type === PropertyType.Periodic
-                : e.Type === PropertyType.PeriodicWithDimension
-            )
-            .map((e) => e.Name)
-        ),
-      ]
-    }
-    const selectedEventTypeUUIDs = getSelectedEventTypes(eventTypeSelectors)
+    const eventTypeUUIDs = eventTypeUUIDsForProperties(props.datasource, eventTypeSelectors, eventTypes, false)
     return [
       ...new Set(
         eventTypeProperties
@@ -372,7 +357,7 @@ export const EventFilter = (props: Props): JSX.Element => {
               ? e.Type === PropertyType.PeriodicWithDimension || e.Type === PropertyType.Periodic
               : e.Type === PropertyType.PeriodicWithDimension
           )
-          .filter((e) => selectedEventTypeUUIDs.includes(e.EventTypeUUID))
+          .filter((e) => eventTypeUUIDs.includes(e.EventTypeUUID))
           .map((e) => e.Name)
       ),
     ]

--- a/src/QueryEditor/util.test.ts
+++ b/src/QueryEditor/util.test.ts
@@ -1,6 +1,7 @@
 import {
   buildLazyCascaderOptions,
   debouncePromise,
+  eventTypeUUIDsForProperties,
   fetchLazyChildOptions,
   getAggregations,
   getAggregationsForDatatypes,
@@ -407,6 +408,59 @@ describe('resolvePropertyDatatype', () => {
 
   it('falls back to string for an unknown property', () => {
     expect(resolvePropertyDatatype('Batch number', eventTypeProperties, [])).toBe(PropertyDatatype.String)
+  })
+})
+
+describe('eventTypeUUIDsForProperties', () => {
+  const eventTypes: EventType[] = [
+    { Name: 'Batch', UUID: 'batch-uuid', Description: '' },
+    { Name: 'Phase', UUID: 'phase-uuid', Description: '', ParentUUID: 'batch-uuid' },
+    { Name: 'Standalone', UUID: 'standalone-uuid', Description: '' },
+  ]
+
+  const makeEventTypeDS = (resolve: (value: string) => string[]) =>
+    ({
+      multiSelectReplace: jest.fn(resolve),
+      containsTemplate: (value: string) => value.startsWith('$'),
+    } as unknown as DataSource)
+
+  it('honours a concrete selection', () => {
+    const ds = makeEventTypeDS((value) => [value])
+    expect(eventTypeUUIDsForProperties(ds, ['phase-uuid'], eventTypes, false)).toEqual(['phase-uuid'])
+    expect(eventTypeUUIDsForProperties(ds, ['phase-uuid'], eventTypes, true)).toEqual(['batch-uuid'])
+  })
+
+  it('honours a template variable that resolves to known event types', () => {
+    const ds = makeEventTypeDS((value) => (value === '$EventTypes' ? ['phase-uuid'] : [value]))
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes'], eventTypes, false)).toEqual(['phase-uuid'])
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes'], eventTypes, true)).toEqual(['batch-uuid'])
+  })
+
+  it('offers every event type when a template variable resolves to nothing known', () => {
+    const ds = makeEventTypeDS((value) => [value])
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes'], eventTypes, false)).toEqual([
+      'batch-uuid',
+      'phase-uuid',
+      'standalone-uuid',
+    ])
+  })
+
+  it('offers only event types that are a parent when unresolvable and asked for parents', () => {
+    const ds = makeEventTypeDS((value) => [value])
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes'], eventTypes, true)).toEqual(['batch-uuid'])
+  })
+
+  it('does not widen when one of several selectors resolves', () => {
+    const ds = makeEventTypeDS((value) => (value === '$EventTypes' ? ['phase-uuid'] : [value]))
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes', 'standalone-uuid'], eventTypes, false)).toEqual([
+      'phase-uuid',
+      'standalone-uuid',
+    ])
+  })
+
+  it('returns nothing for an empty selection', () => {
+    const ds = makeEventTypeDS((value) => [value])
+    expect(eventTypeUUIDsForProperties(ds, [], eventTypes, false)).toEqual([])
   })
 })
 

--- a/src/QueryEditor/util.test.ts
+++ b/src/QueryEditor/util.test.ts
@@ -8,8 +8,10 @@ import {
   isLazyLoadingEnabled,
   matchedAssets,
   migrateMeasurementQuery,
+  parentEventTypeUUIDs,
   propertyFilterToQueryTags,
   resolveAssetLabel,
+  resolvePropertyDatatype,
   resolveSelectedAssets,
   searchAssetsAndProperties,
   selectable,
@@ -19,7 +21,16 @@ import {
   updateTreeChildren,
   valueFiltersToQueryTags,
 } from './util'
-import { AggregationName, Asset, AssetProperty, MeasurementQuery } from 'types'
+import {
+  AggregationName,
+  Asset,
+  AssetProperty,
+  EventType,
+  EventTypeProperty,
+  MeasurementQuery,
+  PropertyDatatype,
+  PropertyType,
+} from 'types'
 import { DataSource } from 'datasource'
 
 const UUID = '11111111-1111-1111-1111-111111111111'
@@ -184,9 +195,7 @@ describe('searchAssetsAndProperties', () => {
     const res = await searchAssetsAndProperties(ds, 'speed')
 
     expect(getAssets).toHaveBeenNthCalledWith(2, { UUIDs: ['parent-1'] })
-    expect(res).toEqual([
-      { label: '📦 Line\\Pump\\📏 Speed', value: ['parent-1', 'p1'], description: 'Line\\Pump' },
-    ])
+    expect(res).toEqual([{ label: '📦 Line\\Pump\\📏 Speed', value: ['parent-1', 'p1'], description: 'Line\\Pump' }])
   })
 })
 
@@ -339,6 +348,65 @@ describe('propertyFilterToQueryTags', () => {
 
   it('returns empty array for empty input', () => {
     expect(propertyFilterToQueryTags([])).toEqual([])
+  })
+})
+
+describe('parentEventTypeUUIDs', () => {
+  const eventTypes: EventType[] = [
+    { Name: 'Batch', UUID: 'batch-uuid', Description: '' },
+    { Name: 'Phase', UUID: 'phase-uuid', Description: '', ParentUUID: 'batch-uuid' },
+    { Name: 'Unrelated', UUID: 'other-uuid', Description: '' },
+  ]
+
+  it('returns the parents of the selected event types', () => {
+    expect(parentEventTypeUUIDs(['phase-uuid'], eventTypes)).toEqual(['batch-uuid'])
+  })
+
+  it('returns nothing when the selected event type has no parent', () => {
+    expect(parentEventTypeUUIDs(['other-uuid'], eventTypes)).toEqual([])
+  })
+
+  it('returns nothing for an unresolved template variable', () => {
+    expect(parentEventTypeUUIDs(['$EventTypes'], eventTypes)).toEqual([])
+  })
+})
+
+describe('resolvePropertyDatatype', () => {
+  const eventTypeProperties: EventTypeProperty[] = [
+    {
+      Name: 'Batch number',
+      UUID: 'prop-1',
+      EventTypeUUID: 'batch-uuid',
+      Datatype: PropertyDatatype.String,
+      Type: PropertyType.Simple,
+    },
+    {
+      Name: 'Weight',
+      UUID: 'prop-2',
+      EventTypeUUID: 'batch-uuid',
+      Datatype: PropertyDatatype.Number,
+      Type: PropertyType.Simple,
+    },
+    {
+      Name: 'Batch number',
+      UUID: 'prop-3',
+      EventTypeUUID: 'other-uuid',
+      Datatype: PropertyDatatype.Number,
+      Type: PropertyType.Simple,
+    },
+  ]
+
+  it('resolves the datatype from the given event types', () => {
+    expect(resolvePropertyDatatype('Batch number', eventTypeProperties, ['batch-uuid'])).toBe(PropertyDatatype.String)
+    expect(resolvePropertyDatatype('Weight', eventTypeProperties, ['batch-uuid'])).toBe(PropertyDatatype.Number)
+  })
+
+  it('ignores properties of event types that are not selected', () => {
+    expect(resolvePropertyDatatype('Weight', eventTypeProperties, ['other-uuid'])).toBe(PropertyDatatype.String)
+  })
+
+  it('falls back to string for an unknown property', () => {
+    expect(resolvePropertyDatatype('Batch number', eventTypeProperties, [])).toBe(PropertyDatatype.String)
   })
 })
 
@@ -565,7 +633,14 @@ describe('buildLazyCascaderOptions', () => {
 
   it('marks leaf when HasChildren and HasAssetProperties are both false (>= v8.2.0)', () => {
     const flagged: Asset[] = [
-      { Name: 'Leaf', UUID: 'uuid-leaf', Description: '', Status: 'active', HasChildren: false, HasAssetProperties: false },
+      {
+        Name: 'Leaf',
+        UUID: 'uuid-leaf',
+        Description: '',
+        Status: 'active',
+        HasChildren: false,
+        HasAssetProperties: false,
+      },
     ]
     const result = buildLazyCascaderOptions(flagged, [])
     expect(result[0].isLeaf).toBe(true)
@@ -573,7 +648,14 @@ describe('buildLazyCascaderOptions', () => {
 
   it('keeps node expandable when HasChildren is true', () => {
     const flagged: Asset[] = [
-      { Name: 'Branch', UUID: 'uuid-branch', Description: '', Status: 'active', HasChildren: true, HasAssetProperties: false },
+      {
+        Name: 'Branch',
+        UUID: 'uuid-branch',
+        Description: '',
+        Status: 'active',
+        HasChildren: true,
+        HasAssetProperties: false,
+      },
     ]
     const result = buildLazyCascaderOptions(flagged, [])
     expect(result[0].isLeaf).toBe(false)
@@ -581,7 +663,14 @@ describe('buildLazyCascaderOptions', () => {
 
   it('keeps node expandable when HasAssetProperties is true', () => {
     const flagged: Asset[] = [
-      { Name: 'WithProps', UUID: 'uuid-props', Description: '', Status: 'active', HasChildren: false, HasAssetProperties: true },
+      {
+        Name: 'WithProps',
+        UUID: 'uuid-props',
+        Description: '',
+        Status: 'active',
+        HasChildren: false,
+        HasAssetProperties: true,
+      },
     ]
     const result = buildLazyCascaderOptions(flagged, [])
     expect(result[0].isLeaf).toBe(false)
@@ -594,9 +683,7 @@ describe('updateTreeChildren', () => {
       { label: '📦 Root', value: 'root-1', isLeaf: false },
       { label: '📦 Root2', value: 'root-2', isLeaf: false },
     ]
-    const children = [
-      { label: '📦 Child', value: 'child-1', isLeaf: false },
-    ]
+    const children = [{ label: '📦 Child', value: 'child-1', isLeaf: false }]
     const result = updateTreeChildren(options, 'root-1', children)
     expect(result[0].items).toHaveLength(1)
     expect(result[0].items![0].value).toBe('child-1')
@@ -604,9 +691,7 @@ describe('updateTreeChildren', () => {
   })
 
   it('marks node as isLeaf when children are empty', () => {
-    const options = [
-      { label: '📦 Root', value: 'root-1', isLeaf: false },
-    ]
+    const options = [{ label: '📦 Root', value: 'root-1', isLeaf: false }]
     const result = updateTreeChildren(options, 'root-1', [])
     expect(result[0].isLeaf).toBe(true)
     expect(result[0].items).toBeUndefined()
@@ -653,9 +738,7 @@ describe('updateTreeChildren', () => {
   })
 
   it('returns unchanged array when parent not found', () => {
-    const options = [
-      { label: '📦 Root', value: 'root-1', isLeaf: false },
-    ]
+    const options = [{ label: '📦 Root', value: 'root-1', isLeaf: false }]
     const result = updateTreeChildren(options, 'nonexistent', [])
     expect(result).toBe(options)
   })
@@ -667,10 +750,7 @@ describe('updateTreeChildren', () => {
       isLeaf: false,
       items: [{ label: '📦 Sub', value: 'sub', isLeaf: false }],
     }
-    const options = [
-      untouched,
-      { label: '📦 Target', value: 'target', isLeaf: false },
-    ]
+    const options = [untouched, { label: '📦 Target', value: 'target', isLeaf: false }]
     const result = updateTreeChildren(options, 'target', [{ label: '📦 Child', value: 'child', isLeaf: false }])
     expect(result).not.toBe(options)
     expect(result[0]).toBe(untouched)
@@ -678,9 +758,7 @@ describe('updateTreeChildren', () => {
   })
 
   it('returns new top-level array reference (immutable)', () => {
-    const options = [
-      { label: '📦 Root', value: 'root-1', isLeaf: false },
-    ]
+    const options = [{ label: '📦 Root', value: 'root-1', isLeaf: false }]
     const result = updateTreeChildren(options, 'root-1', [])
     expect(result).not.toBe(options)
     expect(result[0]).not.toBe(options[0])

--- a/src/QueryEditor/util.ts
+++ b/src/QueryEditor/util.ts
@@ -482,6 +482,37 @@ export function resolvePropertyDatatype(
   )
 }
 
+// Returns the event type UUIDs whose properties the property pickers may offer.
+// A template variable that resolves to no known event type says nothing about
+// the selection (variable not loaded yet, an all-value that is a regex, a
+// per-row repeat variable this editor has no scoped vars for), so every
+// candidate is offered rather than none: filterProperties drops the properties
+// that are missing from this list, and dropping the user's selection is worse
+// than offering too much. A selection that does resolve is honoured, so the
+// pickers stop offering properties of event types that are not selected.
+export function eventTypeUUIDsForProperties(
+  datasource: DataSource,
+  eventTypeSelectors: string[],
+  eventTypes: EventType[],
+  onlyParentProperties: boolean
+): string[] {
+  const isKnownEventType = (uuid: string): boolean => eventTypes.some((e) => e.UUID === uuid)
+  const unresolvable = eventTypeSelectors.some(
+    (et) => datasource.containsTemplate(et) && !datasource.multiSelectReplace(et).some(isKnownEventType)
+  )
+
+  if (!unresolvable) {
+    const selectedEventTypeUUIDs = eventTypeSelectors.flatMap((e) => datasource.multiSelectReplace(e))
+    return onlyParentProperties ? parentEventTypeUUIDs(selectedEventTypeUUIDs, eventTypes) : selectedEventTypeUUIDs
+  }
+
+  // Narrow the fallback to the event types that are a parent of something, so a
+  // parent picker never offers a property that exists on child types only.
+  return onlyParentProperties
+    ? [...new Set(eventTypes.map((e) => e.ParentUUID).filter((uuid): uuid is string => !!uuid))]
+    : eventTypes.map((e) => e.UUID)
+}
+
 export function matchedAssets(selectedAssets: string[], assets: Asset[]): Asset[] {
   if (selectedAssets.length === 0) {
     return []

--- a/src/QueryEditor/util.ts
+++ b/src/QueryEditor/util.ts
@@ -8,10 +8,13 @@ import {
   AssetProperty,
   Attributes,
   EventPropertyFilter,
+  EventType,
+  EventTypeProperty,
   FillType,
   Measurement,
   MeasurementQuery,
   MeasurementQueryOptions,
+  PropertyDatatype,
   PropertyType,
   ValueFilter,
 } from 'types'
@@ -106,9 +109,7 @@ export async function searchAssetsAndProperties(
   // name when the keyword is a regex, ILIKE on name/description otherwise), so
   // they are used as-is.
   const assetMap = new Map(assets.map((a) => [a.UUID, a]))
-  const missingParentUUIDs = [...new Set(
-    properties.map((p) => p.AssetUUID).filter((uuid) => !assetMap.has(uuid))
-  )]
+  const missingParentUUIDs = [...new Set(properties.map((p) => p.AssetUUID).filter((uuid) => !assetMap.has(uuid)))]
   if (missingParentUUIDs.length > 0) {
     const parentAssets = await datasource.getAssets({ UUIDs: missingParentUUIDs })
     for (const asset of parentAssets) {
@@ -331,10 +332,7 @@ export function getChildAssets(
   return result.sort(sortByLabel)
 }
 
-export function buildLazyCascaderOptions(
-  assets: Asset[],
-  assetProperties: AssetProperty[] = []
-): CascaderOption[] {
+export function buildLazyCascaderOptions(assets: Asset[], assetProperties: AssetProperty[] = []): CascaderOption[] {
   const result: CascaderOption[] = assets.map((asset) => {
     const properties: CascaderOption[] = assetProperties
       .filter((prop) => prop.AssetUUID === asset.UUID)
@@ -457,6 +455,31 @@ export function propertyFilterToQueryTags(filter: EventPropertyFilter[]): QueryT
   })
 
   return queryTags
+}
+
+// Returns the UUIDs of the event types that are the parent of one of the
+// selected event types. Selectors must already be resolved to UUIDs: template
+// variables never match an event type UUID.
+export function parentEventTypeUUIDs(selectedEventTypeUUIDs: string[], eventTypes: EventType[]): string[] {
+  const selectedEventTypes = eventTypes.filter((e) => selectedEventTypeUUIDs.includes(e.UUID))
+
+  return eventTypes.filter((e) => selectedEventTypes.some((et) => e.UUID === et.ParentUUID)).map((e) => e.UUID)
+}
+
+// Resolves the datatype of a property from the properties of the given event
+// types. An unresolved property falls back to string: it is the datatype the
+// backend assumes for an empty one, and it is the only cast historian cannot
+// fail on. A number fallback makes historian cast the filter value to real,
+// which errors out the whole query for any non-numeric value.
+export function resolvePropertyDatatype(
+  property: string,
+  eventTypeProperties: EventTypeProperty[],
+  eventTypeUUIDs: string[]
+): PropertyDatatype {
+  return (
+    eventTypeProperties.filter((e) => eventTypeUUIDs.includes(e.EventTypeUUID)).find((e) => e.Name === property)
+      ?.Datatype ?? PropertyDatatype.String
+  )
 }
 
 export function matchedAssets(selectedAssets: string[], assets: Asset[]): Asset[] {


### PR DESCRIPTION
Fixes [AB#36863](https://dev.azure.com/factry/Historian/_workitems/edit/36863).

A `WHERE parent:<property> IN $var` event filter made Historian cast a string property filter to `real`, so Postgres rejected the value and the whole panel errored out:

```
ERROR: invalid input syntax for type real: ""ROS26CBA175""
CONTEXT: unnamed portal parameter $16 = '...'
```

`CONTEXT: unnamed portal parameter $16` shows the failing coercion is the filter value, not the JSON column, so a wrong `Datatype` on its own breaks the query regardless of what is stored.

## Fix 1 — datatype resolution (the bug)

`getSelectedParentEventTypes` matched event type UUIDs against the **raw** selectors, while its sibling `getSelectedEventTypes` interpolates them first via `multiSelectReplace`. With `Event types = $EventTypes` no parent event type resolved, the property was not found, and `getDatatype` fell through to `if (!datatype) return PropertyDatatype.Number`.

- Interpolate the selectors before matching.
- Fall back to `string` rather than `number` when the datatype cannot be resolved. `fixPropertyFilterValues` (`pkg/api/query.go`) already defaults an empty datatype to `"string"`, and a text cast is the only one Postgres cannot fail on.
- Extract `parentEventTypeUUIDs` and `resolvePropertyDatatype` to `QueryEditor/util.ts` so they are unit-testable.

## Fix 2 — property pickers

The `string` fallback turns a mis-picked key from a 500 into a silently empty panel, which exposes a pre-existing bug: `availableSimpleProperties` short-circuited on any templated selector and returned every simple property, **ignoring its own `onlyParentProperties` argument**. Behind a template variable the `parent:` key list was identical to the own-property list, so `parent:<prop>` was offered for properties that exist on child event types only.

`eventTypeUUIDsForProperties` now decides the scope once: honour a selection that resolves, and keep the permissive list only for selectors that resolve to no known event type (variable not loaded, an all-value that is a regex, a per-row repeat variable the editor has no scoped vars for). The parent fallback narrows to event types that are a parent of something. `availablePeriodicProperties` had the same short-circuit and now shares the helper.

## Behaviour to be aware of

- **Fewer options in the WHERE key and Properties dropdowns** when event types come from a template variable that resolves. Those extra entries could never match anything, but the change is visible, in the events editor, the annotations editor and the property-values variable editor.
- **`filterProperties` can drop a saved property.** It deletes saved `Properties` missing from that list, on asset change (`:244`), event-type change (`:198`) and query-type change (`:271`). Same rule concrete selections already follow, which is why the unresolvable case keeps the permissive list instead of returning nothing.
- **Nothing renders the datatype and no migration rewrites it**, so existing saved filters keep their stored `Datatype` until someone edits that WHERE row.
- **An unresolvable datatype now compares as text.** `=`/`IN` behave as before; `<`/`>`/`<=`/`>=` compare lexically instead of numerically. Previously that case errored out on non-numeric values and worked on numeric ones.

## Verification

- Regression test drives the WHERE section with `EventTypes: ['$EventTypes']`; confirmed failing on `main` with `"Datatype": "number"`.
- Second component test asserts the key list offers `Phase step` and `parent:Batch number` but not `parent:Phase step` or `Batch number`; confirmed failing on the first commit.
- Unit tests for `parentEventTypeUUIDs`, `resolvePropertyDatatype` and `eventTypeUUIDsForProperties`.
- Full suite green (202 tests / 15 suites), `tsc --noEmit` clean, ESLint clean.
- Not yet exercised against a live Grafana and Historian.

## Open questions and follow-up

Two things in the report this PR does not explain, worth checking against the customer's dashboard JSON before the patch release:

- The logged SQL joined `event_properties`, not `parent_properties`, so that request carried `Parent=false` despite a `parent:`-prefixed property. Current code always sets `Parent: isParent`, which points at an older plugin at the customer.
- The variable value carries literal quotes (`"ROS26CBA175"`). Even with `Datatype: string` that matches nothing, since `properties->>` returns unquoted text, unless the stored JSON value is itself double-encoded.

Both fixes here are client-side mitigations: Historian still trusts the client's `Datatype` and turns a wrong one into a 500. The durable fix is server-side resolution, raised as a discovery item: [Historian resolves event property filter datatype server-side](https://app.notion.com/p/3b56b22cbce3813b9f76d7f767d33f20).
