### PR TITLE
fix(events): narrow the property pickers behind a template variable

### DIFF
--- a/src/QueryEditor/EventFilter.test.tsx
+++ b/src/QueryEditor/EventFilter.test.tsx
@@ -29,12 +29,20 @@ jest.mock('components/Cascader/Cascader', () => ({
   default: ({ initialLabel }: { initialLabel: string }) => <input data-testid="assets" readOnly value={initialLabel} />,
 }))
 
-// TagsSection test double: keeps a handle on the onChange EventFilter passes
-// down so tests can drive the WHERE section without rendering the real editor.
+// TagsSection test double: keeps a handle on the props EventFilter passes down
+// so tests can drive the WHERE section without rendering the real editor.
 let mockTagsSectionOnChange: ((tags: QueryTag[]) => void) | undefined
+let mockTagsSectionGetTagKeyOptions: (() => Promise<string[]>) | undefined
 jest.mock('components/TagsSection/TagsSection', () => ({
-  TagsSection: ({ onChange }: { onChange: (tags: QueryTag[]) => void }) => {
+  TagsSection: ({
+    onChange,
+    getTagKeyOptions,
+  }: {
+    onChange: (tags: QueryTag[]) => void
+    getTagKeyOptions: () => Promise<string[]>
+  }) => {
     mockTagsSectionOnChange = onChange
+    mockTagsSectionGetTagKeyOptions = getTagKeyOptions
     return null
   },
 }))
@@ -130,5 +138,52 @@ describe('EventFilter', () => {
         ],
       })
     )
+  })
+
+  it('only offers parent keys that exist on the parent event type', async () => {
+    const eventTypes: EventType[] = [
+      { Name: 'Batch', UUID: 'batch-uuid', Description: '' },
+      { Name: 'Phase', UUID: 'phase-uuid', Description: '', ParentUUID: 'batch-uuid' },
+    ]
+    const simple = (name: string, uuid: string, eventTypeUUID: string): EventTypeProperty => ({
+      Name: name,
+      UUID: uuid,
+      EventTypeUUID: eventTypeUUID,
+      Datatype: PropertyDatatype.String,
+      Type: PropertyType.Simple,
+    })
+    const datasource = createMockDatasource({
+      getEventTypes: jest.fn().mockResolvedValue(eventTypes),
+      getEventTypeProperties: jest
+        .fn()
+        .mockResolvedValue([
+          simple('Batch number', 'prop-1', 'batch-uuid'),
+          simple('Phase step', 'prop-2', 'phase-uuid'),
+        ]),
+      multiSelectReplace: (value: string) => (value === '$EventTypes' ? ['phase-uuid'] : [value]),
+      containsTemplate: (value: string) => value.startsWith('$'),
+    })
+    const query = {
+      Assets: [],
+      EventTypes: ['$EventTypes'],
+      Properties: [],
+      Statuses: [],
+      PropertyFilter: [],
+      IncludeParentInfo: true,
+    } as unknown as EventQuery
+
+    render(<EventFilter query={query} datasource={datasource} onChangeQuery={jest.fn()} />)
+    await waitFor(() => {
+      expect(mockTagsSectionGetTagKeyOptions).toBeDefined()
+    })
+
+    const keys = await mockTagsSectionGetTagKeyOptions!()
+
+    expect(keys).toContain('Phase step')
+    expect(keys).toContain('parent:Batch number')
+    // 'Phase step' exists on the child only, so it is not a parent key, and
+    // 'Batch number' exists on the parent only, so it is not an own key.
+    expect(keys).not.toContain('parent:Phase step')
+    expect(keys).not.toContain('Batch number')
   })
 })

--- a/src/QueryEditor/EventFilter.tsx
+++ b/src/QueryEditor/EventFilter.tsx
@@ -20,6 +20,7 @@ import {
 import { getValueFilterOperatorsForVersion, KnownOperator, needsValue } from 'util/eventFilter'
 import {
   buildLazyCascaderOptions,
+  eventTypeUUIDsForProperties,
   fetchLazyChildOptions,
   getChildAssets,
   isLazyLoadingEnabled,
@@ -330,40 +331,24 @@ export const EventFilter = (props: Props): JSX.Element => {
   }
 
   const availableSimpleProperties = (eventTypeSelectors: string[], onlyParentProperties = false): string[] => {
-    if (eventTypeSelectors.some((et) => props.datasource.containsTemplate(et))) {
-      return [...new Set(eventTypeProperties.filter((e) => e.Type === PropertyType.Simple).map((e) => e.Name))]
-    }
-    let selectedEventTypeUUIDs: string[] = []
-    if (onlyParentProperties) {
-      selectedEventTypeUUIDs = getSelectedParentEventTypes(eventTypeSelectors)
-    } else {
-      selectedEventTypeUUIDs = getSelectedEventTypes(eventTypeSelectors)
-    }
+    const eventTypeUUIDs = eventTypeUUIDsForProperties(
+      props.datasource,
+      eventTypeSelectors,
+      eventTypes,
+      onlyParentProperties
+    )
     return [
       ...new Set(
         eventTypeProperties
           .filter((e) => e.Type === PropertyType.Simple)
-          .filter((e) => selectedEventTypeUUIDs.includes(e.EventTypeUUID))
+          .filter((e) => eventTypeUUIDs.includes(e.EventTypeUUID))
           .map((e) => e.Name)
       ),
     ]
   }
 
   const availablePeriodicProperties = (eventTypeSelectors: string[]): string[] => {
-    if (eventTypeSelectors.some((et) => props.datasource.containsTemplate(et))) {
-      return [
-        ...new Set(
-          eventTypeProperties
-            .filter((e) =>
-              props.query.Type === PropertyType.Periodic
-                ? e.Type === PropertyType.PeriodicWithDimension || e.Type === PropertyType.Periodic
-                : e.Type === PropertyType.PeriodicWithDimension
-            )
-            .map((e) => e.Name)
-        ),
-      ]
-    }
-    const selectedEventTypeUUIDs = getSelectedEventTypes(eventTypeSelectors)
+    const eventTypeUUIDs = eventTypeUUIDsForProperties(props.datasource, eventTypeSelectors, eventTypes, false)
     return [
       ...new Set(
         eventTypeProperties
@@ -372,7 +357,7 @@ export const EventFilter = (props: Props): JSX.Element => {
               ? e.Type === PropertyType.PeriodicWithDimension || e.Type === PropertyType.Periodic
               : e.Type === PropertyType.PeriodicWithDimension
           )
-          .filter((e) => selectedEventTypeUUIDs.includes(e.EventTypeUUID))
+          .filter((e) => eventTypeUUIDs.includes(e.EventTypeUUID))
           .map((e) => e.Name)
       ),
     ]

--- a/src/QueryEditor/util.test.ts
+++ b/src/QueryEditor/util.test.ts
@@ -1,6 +1,7 @@
 import {
   buildLazyCascaderOptions,
   debouncePromise,
+  eventTypeUUIDsForProperties,
   fetchLazyChildOptions,
   getAggregations,
   getAggregationsForDatatypes,
@@ -407,6 +408,59 @@ describe('resolvePropertyDatatype', () => {
 
   it('falls back to string for an unknown property', () => {
     expect(resolvePropertyDatatype('Batch number', eventTypeProperties, [])).toBe(PropertyDatatype.String)
+  })
+})
+
+describe('eventTypeUUIDsForProperties', () => {
+  const eventTypes: EventType[] = [
+    { Name: 'Batch', UUID: 'batch-uuid', Description: '' },
+    { Name: 'Phase', UUID: 'phase-uuid', Description: '', ParentUUID: 'batch-uuid' },
+    { Name: 'Standalone', UUID: 'standalone-uuid', Description: '' },
+  ]
+
+  const makeEventTypeDS = (resolve: (value: string) => string[]) =>
+    ({
+      multiSelectReplace: jest.fn(resolve),
+      containsTemplate: (value: string) => value.startsWith('$'),
+    } as unknown as DataSource)
+
+  it('honours a concrete selection', () => {
+    const ds = makeEventTypeDS((value) => [value])
+    expect(eventTypeUUIDsForProperties(ds, ['phase-uuid'], eventTypes, false)).toEqual(['phase-uuid'])
+    expect(eventTypeUUIDsForProperties(ds, ['phase-uuid'], eventTypes, true)).toEqual(['batch-uuid'])
+  })
+
+  it('honours a template variable that resolves to known event types', () => {
+    const ds = makeEventTypeDS((value) => (value === '$EventTypes' ? ['phase-uuid'] : [value]))
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes'], eventTypes, false)).toEqual(['phase-uuid'])
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes'], eventTypes, true)).toEqual(['batch-uuid'])
+  })
+
+  it('offers every event type when a template variable resolves to nothing known', () => {
+    const ds = makeEventTypeDS((value) => [value])
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes'], eventTypes, false)).toEqual([
+      'batch-uuid',
+      'phase-uuid',
+      'standalone-uuid',
+    ])
+  })
+
+  it('offers only event types that are a parent when unresolvable and asked for parents', () => {
+    const ds = makeEventTypeDS((value) => [value])
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes'], eventTypes, true)).toEqual(['batch-uuid'])
+  })
+
+  it('does not widen when one of several selectors resolves', () => {
+    const ds = makeEventTypeDS((value) => (value === '$EventTypes' ? ['phase-uuid'] : [value]))
+    expect(eventTypeUUIDsForProperties(ds, ['$EventTypes', 'standalone-uuid'], eventTypes, false)).toEqual([
+      'phase-uuid',
+      'standalone-uuid',
+    ])
+  })
+
+  it('returns nothing for an empty selection', () => {
+    const ds = makeEventTypeDS((value) => [value])
+    expect(eventTypeUUIDsForProperties(ds, [], eventTypes, false)).toEqual([])
   })
 })
 

--- a/src/QueryEditor/util.ts
+++ b/src/QueryEditor/util.ts
@@ -482,6 +482,37 @@ export function resolvePropertyDatatype(
   )
 }
 
+// Returns the event type UUIDs whose properties the property pickers may offer.
+// A template variable that resolves to no known event type says nothing about
+// the selection (variable not loaded yet, an all-value that is a regex, a
+// per-row repeat variable this editor has no scoped vars for), so every
+// candidate is offered rather than none: filterProperties drops the properties
+// that are missing from this list, and dropping the user's selection is worse
+// than offering too much. A selection that does resolve is honoured, so the
+// pickers stop offering properties of event types that are not selected.
+export function eventTypeUUIDsForProperties(
+  datasource: DataSource,
+  eventTypeSelectors: string[],
+  eventTypes: EventType[],
+  onlyParentProperties: boolean
+): string[] {
+  const isKnownEventType = (uuid: string): boolean => eventTypes.some((e) => e.UUID === uuid)
+  const unresolvable = eventTypeSelectors.some(
+    (et) => datasource.containsTemplate(et) && !datasource.multiSelectReplace(et).some(isKnownEventType)
+  )
+
+  if (!unresolvable) {
+    const selectedEventTypeUUIDs = eventTypeSelectors.flatMap((e) => datasource.multiSelectReplace(e))
+    return onlyParentProperties ? parentEventTypeUUIDs(selectedEventTypeUUIDs, eventTypes) : selectedEventTypeUUIDs
+  }
+
+  // Narrow the fallback to the event types that are a parent of something, so a
+  // parent picker never offers a property that exists on child types only.
+  return onlyParentProperties
+    ? [...new Set(eventTypes.map((e) => e.ParentUUID).filter((uuid): uuid is string => !!uuid))]
+    : eventTypes.map((e) => e.UUID)
+}
+
 export function matchedAssets(selectedAssets: string[], assets: Asset[]): Asset[] {
   if (selectedAssets.length === 0) {
     return []


### PR DESCRIPTION
Stacked on #176 — review that first, this PR targets its branch. Related to [AB#36863](https://dev.azure.com/factry/Historian/_workitems/edit/36863), not a fix for it.

## Problem

`availableSimpleProperties` short-circuited on *any* templated event-type selector:

```ts
if (eventTypeSelectors.some((et) => props.datasource.containsTemplate(et))) {
  return [...new Set(eventTypeProperties.filter((e) => e.Type === PropertyType.Simple).map((e) => e.Name))]
}
```

Two defects:

1. **`onlyParentProperties` is ignored.** Behind a template variable the `parent:` key list is identical to the own-property list, so `parent:<prop>` is offered for properties that exist on child event types only.
2. **It does not resolve what it now can.** `multiSelectReplace` resolves `$EventTypes` at editor time — #176 relies on exactly that — so the permissive list is broader than it needs to be.

Picking an over-listed key produces a filter that cannot match. Before #176 that surfaced as a Postgres 500 from the `real` cast; with #176 the datatype resolves to `string`, the query runs, and the panel is silently empty. "No rows" is the correct answer for filtering on a property the event does not have, so this is the right place to fix it: don't offer the key.

`availablePeriodicProperties` has the same short-circuit (no parent flag there, so only defect 2 applies).

## Change

`eventTypeUUIDsForProperties` in `QueryEditor/util.ts` decides the scope once:

- Resolve the selectors. A selection that resolves is honoured, including behind a template variable, and `onlyParentProperties` maps it through `parentEventTypeUUIDs`.
- Fall back to the permissive list only for selectors that resolve to **no known event type** — variable not loaded yet, an all-value that is a regex, a per-row repeat variable this editor has no scoped vars for.
- Narrow that fallback for the parent case to event types that are a parent of something, so a parent picker never offers a child-only property.

## Behaviour change to be aware of

`availableSimpleProperties` feeds `availableProperties` → `filterProperties`, which **deletes** saved `Properties` that are not in the list, on asset change (`:244`), event-type change (`:198`) and query-type change (`:271`).

With a resolvable variable the list is now narrower, so a saved property belonging to an event type outside the resolved selection gets dropped on the next such change. That is the same rule already applied to concrete selections, so it is intended — but it is the reason the unresolvable case keeps the permissive list rather than returning nothing, and that guard is what the `eventTypeUUIDsForProperties` tests pin down.

## Verification

- New component test asserts the WHERE key list offers `Phase step` and `parent:Batch number` but not `parent:Phase step` or `Batch number`. Confirmed it fails on the parent commit.
- Six unit tests for `eventTypeUUIDsForProperties` covering concrete, resolvable-template, unresolvable-template (own and parent), mixed selectors, and empty selection.
- Full suite green (202 tests / 15 suites), `tsc --noEmit` clean, ESLint clean.
- Not yet exercised against a live Grafana + Historian.
