### PR TITLE
fix: override js-cookie to 3.0.8 and re-enable the plugin-validator analyzers

### DIFF
--- a/.plugincheck.yaml
+++ b/.plugincheck.yaml
@@ -1,3 +1,13 @@
+# The global block is what enables every analyzer the validator ships. Without
+# it, passing this file with -config leaves only the analyzers named below
+# switched on, so the release gate (which runs the validator with no -config)
+# checks things CI does not. Values match config/default.yaml upstream.
+global:
+  enabled: true
+  severity: warning
+  jsonOutput: false
+  reportAll: false
+
 analyzers:
   go-manifest:
     rules:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   diff@4: 4.0.4
   dompurify: 3.4.13
   fast-uri: 3.1.5
+  js-cookie: 3.0.8
   js-yaml@3: 3.15.1
   js-yaml@4: 4.3.1
   nanoid@3: 3.3.18
@@ -3102,8 +3103,8 @@ packages:
   jquery@3.7.1:
     resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
 
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -8600,7 +8601,7 @@ snapshots:
 
   jquery@3.7.1: {}
 
-  js-cookie@2.2.1: {}
+  js-cookie@3.0.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -9455,7 +9456,7 @@ snapshots:
       copy-to-clipboard: 3.3.3
       fast-deep-equal: 3.1.3
       fast-shallow-equal: 1.0.0
-      js-cookie: 2.2.1
+      js-cookie: 3.0.8
       nano-css: 5.6.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ overrides:
   'diff@4': 4.0.4
   dompurify: 3.4.13
   fast-uri: 3.1.5
+  js-cookie: 3.0.8
   'js-yaml@3': 3.15.1
   'js-yaml@4': 4.3.1
   'nanoid@3': 3.3.18


### PR DESCRIPTION
The v3.3.0 release run failed on the "Validate plugin" step: `@grafana/plugin-validator` runs `osv-scanner` over `pnpm-lock.yaml` and exits 1 on any high or critical finding.

```
error: osv-scanner detected a high severity issue in package js-cookie
detail: SEVERITY: HIGH in package js-cookie, vulnerable to CVE-2026-46625
```

Two commits: one clears the advisory, one makes CI catch the next one before the tag instead of after.

## 1. Override js-cookie to 3.0.8

`js-cookie@2.2.1` arrives transitively through `react-use` <- `@grafana/data@11.6.0`. GHSA-qjx8-664m-686j is a per-instance prototype hijack in its `assign()` helper; the fix landed in 3.0.7.

The audit sweep earlier today deliberately left this one open because `react-use` declares `^2.2.1` and the package is not in the shipped bundle. That reasoning does not survive the release gate, which thresholds on severity, not on whether the code ships.

The major bump is safe:

- `react-use/lib/useCookie.js` only calls `get`, `set` and `remove`. All three are present in 3.x.
- `require('js-cookie')` still resolves under the 3.x `exports` map (`require` -> `dist/js.cookie.js`). It sets no `__esModule`, so tslib's `__importDefault` wraps it and `Cookies.get/set/remove` stay reachable.
- `grep -c cookie dist/module.js` is 0 after a production build: js-cookie is tree-shaken out, so no shipped byte changes.

Verified: `osv-scanner scan source --lockfile=pnpm-lock.yaml` reports 0 critical and 0 high. Three mediums remain (`@opentelemetry/core` 2.0.1 at 5.3, `react-router` 6.30.4 at 6.1 and 5.1), which the validator reports without failing. `pnpm run typecheck`, `pnpm run lint`, `pnpm run test:ci` (213 tests) and `pnpm run build` are all green.

## 2. Enable every plugin-validator analyzer in make validate

`ci.yml` already runs `make validate` on every pull request, which is the same validator the release uses. It has not been checking anything. On the v3.3.0 run it scanned `pnpm-lock.yaml`, found the same 1104 packages the release found, printed nothing and exited 0. Ten minutes later the release failed on that same scan.

The validator's upstream `config/default.yaml` is nothing but a `global:` block, and `-config` **replaces** that file rather than merging into it. `.plugincheck.yaml` carries no `global:` block, so `enabled` fell back to false and only the analyzers the file names stayed switched on, i.e. `go-manifest` alone. The file was added in 69ce315 purely to downgrade `valid-go-manifest` to a warning; disabling everything else was a side effect. The release path passes no `-config` at all, so it gets the full default set. That is the entire difference between the two.

Same zip, same source tree, v3.3.0 lockfile with the advisory still present:

| invocation | exit | output |
| --- | --- | --- |
| `-config .plugincheck.yaml` (what CI does today) | 0 | nothing at all |
| no `-config` (what the release does) | 1 | osv-scanner errors, unsigned plugin warning, sponsorship recommendation, LLM review and code diff skips |
| `-config` with the `global:` block (this PR) | 1 | identical to the release run |

Against a real `mage buildAll` zip on the fixed lockfile this config exits 0, emitting only the unsigned plugin warning and the sponsorship recommendation. `valid-go-manifest` does not fire even with the backend binaries present, because CI validates before the "Sign plugin" step. The downgrade is kept regardless.

## Follow up, not in this PR

`@grafana/plugin-validator@latest` is unpinned in both the `validate` target and `.github/actions/grafana`. Now that the analyzers actually run, both CI and the release gate track whatever upstream published that day, including its LLM review analyzer. That is out of step with this repo's convention of SHA pinning third party actions.

Once merged, the `v3.3.0` tag moves onto the merge commit to re-trigger the release.
