### PR TITLE
ci: enable every plugin-validator analyzer in make validate

### DIFF
--- a/.plugincheck.yaml
+++ b/.plugincheck.yaml
@@ -1,3 +1,13 @@
+# The global block is what enables every analyzer the validator ships. Without
+# it, passing this file with -config leaves only the analyzers named below
+# switched on, so the release gate (which runs the validator with no -config)
+# checks things CI does not. Values match config/default.yaml upstream.
+global:
+  enabled: true
+  severity: warning
+  jsonOutput: false
+  reportAll: false
+
 analyzers:
   go-manifest:
     rules:


### PR DESCRIPTION
`ci.yml` runs `make validate` on every pull request, which is the same `@grafana/plugin-validator` the release uses. It has not been checking anything.

On the v3.3.0 run it scanned `pnpm-lock.yaml`, found the same 1104 packages the release found, printed nothing and exited 0. Ten minutes later the release failed on that same scan with a high severity `js-cookie` advisory.

### Cause

The validator's upstream `config/default.yaml` is nothing but a `global:` block, and `-config` **replaces** that file rather than merging into it. `.plugincheck.yaml` carries no `global:` block, so `enabled` fell back to false and only the analyzers the file names stayed switched on, i.e. `go-manifest` alone. The file was added in 69ce315 purely to downgrade `valid-go-manifest` to a warning; disabling everything else was a side effect.

The release path runs `npx @grafana/plugin-validator@latest -sourceCodeUri file://./ $ZIP` with no `-config`, so it gets the full default analyzer set. That is the entire difference between the two.

### Verification

Same zip, same source tree, v3.3.0 lockfile with the advisory still present:

| invocation | exit | output |
| --- | --- | --- |
| `-config .plugincheck.yaml` (what CI does today) | 0 | nothing at all |
| no `-config` (what the release does) | 1 | osv-scanner errors, unsigned plugin warning, sponsorship recommendation, LLM review and code diff skips |
| `-config` with the `global:` block (this PR) | 1 | identical to the release run |

Against a real `mage buildAll` zip on the fixed lockfile this config exits 0, emitting only the unsigned plugin warning and the sponsorship recommendation. `valid-go-manifest` does not fire even with the backend binaries present, because CI validates before the "Sign plugin" step. The downgrade is kept regardless.

### Note

`@grafana/plugin-validator@latest` is unpinned in both the `validate` target and `.github/actions/grafana`. Now that the analyzers actually run, both CI and the release gate track whatever upstream published that day, including its LLM review analyzer. That is out of step with this repo's convention of SHA pinning third party actions and is worth a follow up.
