### PR TITLE
perf: cache asset-property resolution in the datasource

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,6 +89,11 @@ linters:
         - performance
         - diagnostic
         - style
+      settings:
+        rangeValCopy:
+          # The default of 128 flags harmless copies of medium structs; only a
+          # copy of several hundred bytes per iteration is worth restructuring.
+          sizeThreshold: 512
     exhaustive:
       check:
         - switch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,11 +304,25 @@ The canonical version is defined in `Makefile` (`major`, `minor`, `patch` variab
 
 ---
 
-## DataSource Caching
+## Caching
 
-The `DataSource` class uses a 5-second TTL in-memory cache for metadata requests (assets, measurements, databases, etc.) to avoid redundant network calls during rapid UI interactions. The cache is keyed by request parameters and deduplicates concurrent requests for the same key.
+There are two independent caches. They serve different call paths, so both are needed.
 
-Cache-related fields in `datasource.ts`:
+### Backend resolution cache (`pkg/api/cache.go`)
+
+`resolutionCache[T]` fronts the asset, asset-property and timeseries-database list endpoints. It is what keeps a dashboard refresh from re-resolving asset properties, and it is the only cache on the query path: `QueryData` never goes through the frontend, so alerting and recording rules depend on this one.
+
+- TTL comes from the `resolutionCacheTTL` datasource setting (string of seconds, default `60`, `0` disables). It is provisioning-only, like `timeout` and `queryTimeout`.
+- Concurrent misses on one key share a request through `golang.org/x/sync/singleflight`. The shared fetch runs on `context.WithoutCancel`, so a cancelled panel query cannot fail the callers waiting on it; the HTTP client timeout still bounds it. A waiter whose own context is cancelled returns immediately with that error while the fetch keeps running.
+- A cache belongs to one `api.API`, which is built per datasource instance, so its contents are already scoped to that instance's token and organization. Never make one package-level.
+- Cache keys are encoded query strings, so any code building an indexed parameter from a map must use `util.AddSortedIndexedUUIDs` (or `util.AddSortedIndexedParams` for strings); `url.Values.Encode` sorts by key name only, never by value.
+- Callers opt in through `GetAssetsCached`, `GetAssetPropertiesCached` and `GetTimeseriesDatabasesCached`. The plain methods stay uncached; `CheckHealth` uses one on purpose.
+- Errors are not cached. Entries are bounded at `resolutionCacheMaxEntries` and evicted on write, so there is no janitor goroutine to dispose.
+
+### Frontend metadata cache (`src/datasource.ts`)
+
+A 5-second TTL in-memory cache for `getResource` metadata requests, which saves a Grafana proxy hop during rapid query-editor interaction. It never sees the query path.
+
 - `metadataCache: Map<string, {data, timestamp, timeoutId}>` — stores responses
 - `cacheTTL = 5000` — cache lifetime in milliseconds
 - `pendingRequests: Map<string, Promise<unknown>>` — in-flight request deduplication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@
   - The pre-v6.3.0 asset-property filtering fallback has been removed.
   - All v7.0.0 / v7.1.0 / v7.2.0 / v7.3.0 frontend feature gates have been removed — the corresponding features (datatype filters, value filters, regex/`IN`/`IS NULL`/duration event property filters, periodic-with-dimension property types, time-weighted average aggregation, event property values variable query, asset property keyword/datatype variable filters) are now always available.
 
+### Changes
+
+- **Resolved asset and measurement metadata is now cached.** An asset-measurement query used to resolve its assets and properties against Historian on every panel of every dashboard refresh. The plugin now reuses the resolution for 60 seconds by default, and collapses concurrent lookups for the same assets into a single request, so a cold dashboard load resolves once instead of once per panel.
+  - The lifetime is set with the `resolutionCacheTTL` datasource setting: a number of seconds, `"0"` to disable. It is a provisioning setting like `timeout` and `queryTimeout`, so it is set in the datasource YAML rather than in the UI:
+
+    ```yaml
+    datasources:
+      - name: "Factry Historian"
+        type: "factry-historian-datasource"
+        jsonData:
+          resolutionCacheTTL: "60"
+    ```
+
+  - The TTL is also the bound on staleness: after an asset is reconfigured, dashboards keep showing the previous resolution for at most that long. Lower it if your assets are reconfigured while operators watch the result, and set it to `"0"` if no staleness is acceptable at all.
+  - The connection test is never served from the cache.
+- **Assets addressed by path resolve in one request.** A query listing several asset paths issued one request per path, and Historian rebuilds its whole asset-path tree for each one. The paths now go out as a single filter, in batches sized to keep the request URL within proxy limits.
+
 ## v3.3.0
 
 released: 11/08/2026

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/build/buildinfo"
 )
@@ -18,6 +19,14 @@ const clientName = "factry-historian-datasource"
 // API is used to communicate with the historian API
 type API struct {
 	client *http.Client
+
+	// Asset and measurement metadata resolve to the same result for every panel
+	// of a dashboard refresh, so each list endpoint gets a cache. The caches
+	// hold one client's results, which are already scoped to its token and
+	// organization, so they must not outlive the client.
+	assetCache         *resolutionCache[schemas.Asset]
+	assetPropertyCache *resolutionCache[schemas.AssetProperty]
+	databaseCache      *resolutionCache[schemas.TimeseriesDatabase]
 }
 
 // clientIdentifier returns the "<name>/<version>" string sent in the User-Agent
@@ -92,6 +101,9 @@ type Options struct {
 	Timeout            time.Duration
 	QueryTimeout       time.Duration
 	InsecureSkipVerify bool
+	// ResolutionCacheTTL is how long resolved asset and measurement metadata is
+	// reused. Zero disables the caches.
+	ResolutionCacheTTL time.Duration
 }
 
 // NewAPIWithOptions creates a new instance of API from the given options
@@ -135,11 +147,17 @@ func NewAPIWithOptions(options Options) (*API, error) {
 		return nil, err
 	}
 
-	api := &API{client}
+	api := &API{
+		client:             client,
+		assetCache:         newResolutionCache[schemas.Asset](options.ResolutionCacheTTL),
+		assetPropertyCache: newResolutionCache[schemas.AssetProperty](options.ResolutionCacheTTL),
+		databaseCache:      newResolutionCache[schemas.TimeseriesDatabase](options.ResolutionCacheTTL),
+	}
 	return api, nil
 }
 
-// NewAPIWithToken creates a new instance of API using a token
+// NewAPIWithToken creates a new instance of API using a token. It leaves the
+// resolution caches disabled; only the datasource settings turn them on.
 func NewAPIWithToken(baseURL string, token string, organization string) (*API, error) {
 	return NewAPIWithOptions(Options{
 		URL:          baseURL,

--- a/pkg/api/cache.go
+++ b/pkg/api/cache.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"golang.org/x/sync/singleflight"
+)
+
+// resolutionCacheMaxEntries bounds how many distinct queries a cache holds.
+// Ad-hoc explore queries and template variables produce unbounded key variety,
+// so entries are evicted rather than kept until they expire.
+const resolutionCacheMaxEntries = 1024
+
+type cacheEntry[T any] struct {
+	value  []T
+	expiry time.Time
+}
+
+// resolutionCache serves repeated asset and measurement metadata lookups from
+// memory for at most a TTL. Concurrent misses on the same key share a single
+// request, so the moment an entry expires a dashboard refresh issues one round
+// trip instead of one per panel.
+//
+// A cache belongs to one API client, so its contents are already scoped to that
+// client's token and organization. It must never be shared between clients.
+type resolutionCache[T any] struct {
+	mu      sync.Mutex
+	entries map[string]cacheEntry[T]
+	group   singleflight.Group
+	ttl     time.Duration
+	max     int
+}
+
+// newResolutionCache returns a cache that holds values for ttl. A ttl of zero
+// or less disables caching: every lookup goes to the historian.
+func newResolutionCache[T any](ttl time.Duration) *resolutionCache[T] {
+	return &resolutionCache[T]{
+		entries: map[string]cacheEntry[T]{},
+		ttl:     ttl,
+		max:     resolutionCacheMaxEntries,
+	}
+}
+
+// do returns the cached value for key, or calls fetch and caches the result.
+// The returned slice is a fresh copy, but its elements still share pointer and
+// nested slice fields with the cache, so callers must treat them as read-only.
+func (c *resolutionCache[T]) do(ctx context.Context, key string, fetch func(context.Context) ([]T, error)) ([]T, error) {
+	if c == nil || c.ttl <= 0 {
+		return fetch(ctx)
+	}
+
+	if value, ok := c.get(key); ok {
+		return value, nil
+	}
+
+	// singleflight hands one fetch's result to every waiter, so the request
+	// outlives the caller that started it. Detaching cancellation keeps a panel
+	// that navigates away from failing the queries that are waiting on it. The
+	// HTTP client timeout still bounds the request.
+	ch := c.group.DoChan(key, func() (any, error) {
+		// A caller can lose the race between its cache check and joining the
+		// flight: the previous flight stores its result and is forgotten in
+		// between. Re-checking here turns that into a hit instead of a
+		// duplicate request.
+		if value, ok := c.get(key); ok {
+			return value, nil
+		}
+		fetched, err := fetch(context.WithoutCancel(ctx))
+		if err != nil {
+			return nil, err
+		}
+		c.store(key, fetched)
+		return fetched, nil
+	})
+
+	// The fetch keeps running for the other waiters, but this caller honors
+	// its own cancellation instead of blocking on the shared result.
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-ch:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		return slices.Clone(result.Val.([]T)), nil
+	}
+}
+
+// get returns a copy of the value stored for key while it is still fresh. The
+// copy is made outside the lock: a stored slice is never mutated in place, so
+// concurrent hits need not serialize behind each other's copies.
+func (c *resolutionCache[T]) get(key string) ([]T, bool) {
+	c.mu.Lock()
+	entry, ok := c.entries[key]
+	fresh := ok && time.Now().Before(entry.expiry)
+	c.mu.Unlock()
+
+	if !fresh {
+		return nil, false
+	}
+	return slices.Clone(entry.value), true
+}
+
+// store keeps value under key until the TTL runs out, evicting first the
+// expired entries and then whichever entry expires soonest.
+func (c *resolutionCache[T]) store(key string, value []T) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	if len(c.entries) >= c.max {
+		for k, entry := range c.entries {
+			if !now.Before(entry.expiry) {
+				delete(c.entries, k)
+			}
+		}
+	}
+	if len(c.entries) >= c.max {
+		var (
+			nextKey    string
+			nextExpiry time.Time
+			found      bool
+		)
+		for k, entry := range c.entries {
+			if !found || entry.expiry.Before(nextExpiry) {
+				nextKey, nextExpiry, found = k, entry.expiry, true
+			}
+		}
+		if found {
+			delete(c.entries, nextKey)
+		}
+	}
+
+	c.entries[key] = cacheEntry[T]{value: value, expiry: now.Add(c.ttl)}
+}
+
+// GetAssetsCached is GetAssets served from the resolution cache.
+func (api *API) GetAssetsCached(ctx context.Context, query string) ([]schemas.Asset, error) {
+	return api.assetCache.do(ctx, query, func(ctx context.Context) ([]schemas.Asset, error) {
+		return api.GetAssets(ctx, query)
+	})
+}
+
+// GetAssetPropertiesCached is GetAssetProperties served from the resolution cache.
+func (api *API) GetAssetPropertiesCached(ctx context.Context, query string) ([]schemas.AssetProperty, error) {
+	return api.assetPropertyCache.do(ctx, query, func(ctx context.Context) ([]schemas.AssetProperty, error) {
+		return api.GetAssetProperties(ctx, query)
+	})
+}
+
+// GetTimeseriesDatabasesCached is GetTimeseriesDatabases served from the
+// resolution cache. The health check deliberately keeps using the uncached call
+// so it always reaches the historian.
+func (api *API) GetTimeseriesDatabasesCached(ctx context.Context, query string) ([]schemas.TimeseriesDatabase, error) {
+	return api.databaseCache.do(ctx, query, func(ctx context.Context) ([]schemas.TimeseriesDatabase, error) {
+		return api.GetTimeseriesDatabases(ctx, query)
+	})
+}

--- a/pkg/api/cache_test.go
+++ b/pkg/api/cache_test.go
@@ -1,0 +1,321 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestCache returns a cache plus a counting fetch that yields one value per
+// call. Tests that depend on the TTL run under synctest, where time.Now is
+// virtual and a time.Sleep advances it.
+func newTestCache(t *testing.T, ttl time.Duration) (*resolutionCache[string], *atomic.Int64, func(context.Context) ([]string, error)) {
+	t.Helper()
+	cache := newResolutionCache[string](ttl)
+
+	calls := &atomic.Int64{}
+	fetch := func(context.Context) ([]string, error) {
+		return []string{"value-" + strconv.FormatInt(calls.Add(1), 10)}, nil
+	}
+	return cache, calls, fetch
+}
+
+func TestResolutionCacheServesRepeatsFromMemory(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		cache, calls, fetch := newTestCache(t, time.Minute)
+
+		first, err := cache.do(context.Background(), "key", fetch)
+		require.NoError(t, err)
+
+		time.Sleep(59 * time.Second)
+		second, err := cache.do(context.Background(), "key", fetch)
+		require.NoError(t, err)
+
+		assert.Equal(t, first, second)
+		assert.Equal(t, int64(1), calls.Load(), "a repeat inside the TTL must not reach the historian")
+	})
+}
+
+func TestResolutionCacheRefetchesAfterTTL(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		cache, calls, fetch := newTestCache(t, time.Minute)
+
+		first, err := cache.do(context.Background(), "key", fetch)
+		require.NoError(t, err)
+
+		time.Sleep(time.Minute)
+		second, err := cache.do(context.Background(), "key", fetch)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, first, second, "a reconfigured asset must be picked up once the TTL passes")
+		assert.Equal(t, int64(2), calls.Load())
+	})
+}
+
+func TestResolutionCacheKeysOnTheQuery(t *testing.T) {
+	t.Parallel()
+
+	cache, calls, fetch := newTestCache(t, time.Minute)
+
+	first, err := cache.do(context.Background(), "AssetUUIDs[0]=a", fetch)
+	require.NoError(t, err)
+	second, err := cache.do(context.Background(), "AssetUUIDs[0]=b", fetch)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second)
+	assert.Equal(t, int64(2), calls.Load())
+}
+
+// GetAssetProperties is called with an empty query to fetch every property, so
+// the empty string is a real key and must not be confused with "no key".
+func TestResolutionCacheHandlesTheEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	cache, calls, fetch := newTestCache(t, time.Minute)
+
+	first, err := cache.do(context.Background(), "", fetch)
+	require.NoError(t, err)
+	second, err := cache.do(context.Background(), "", fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+// A cold dashboard whose panels all resolve the same assets issues one
+// request, not one per panel.
+func TestResolutionCacheCollapsesConcurrentMissesOnOneKey(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		cache, calls, _ := newTestCache(t, time.Minute)
+
+		// The fetch stays blocked until every caller is parked, so a caller
+		// that fails to join the flight must enter the fetch and be counted.
+		release := make(chan struct{})
+		entries := &atomic.Int64{}
+		blocking := func(context.Context) ([]string, error) {
+			entries.Add(1)
+			<-release
+			return []string{"value-" + strconv.FormatInt(calls.Add(1), 10)}, nil
+		}
+
+		const callers = 20
+		results := make([][]string, callers)
+		done := sync.WaitGroup{}
+		done.Add(callers)
+		for i := range callers {
+			go func() {
+				defer done.Done()
+				value, err := cache.do(context.Background(), "key", blocking)
+				assert.NoError(t, err)
+				results[i] = value
+			}()
+		}
+
+		// Wait returns once every goroutine in the bubble is durably blocked:
+		// each caller is either inside the fetch waiting on release or parked
+		// in the shared flight. The count is exact, not a race window.
+		synctest.Wait()
+		assert.Equal(t, int64(1), entries.Load(), "concurrent misses on one key must share a single request")
+
+		close(release)
+		done.Wait()
+
+		assert.Equal(t, int64(1), calls.Load())
+		for i := range results {
+			assert.Equal(t, results[0], results[i], "every caller must get the shared result")
+		}
+	})
+}
+
+func TestResolutionCacheFetchesDifferentKeysConcurrently(t *testing.T) {
+	t.Parallel()
+
+	cache, calls, fetch := newTestCache(t, time.Minute)
+
+	const callers = 8
+	done := sync.WaitGroup{}
+	done.Add(callers)
+	for i := range callers {
+		go func() {
+			defer done.Done()
+			_, err := cache.do(context.Background(), strconv.Itoa(i), fetch)
+			assert.NoError(t, err)
+		}()
+	}
+	done.Wait()
+
+	assert.Equal(t, int64(callers), calls.Load(), "distinct keys are distinct requests")
+}
+
+func TestResolutionCacheDoesNotCacheErrors(t *testing.T) {
+	t.Parallel()
+
+	cache, _, _ := newTestCache(t, time.Minute)
+
+	wantErr := errors.New("historian is down")
+	calls := 0
+	failing := func(context.Context) ([]string, error) {
+		calls++
+		if calls == 1 {
+			return nil, wantErr
+		}
+		return []string{"recovered"}, nil
+	}
+
+	_, err := cache.do(context.Background(), "key", failing)
+	require.ErrorIs(t, err, wantErr)
+
+	value, err := cache.do(context.Background(), "key", failing)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"recovered"}, value, "a failed lookup must be retried, not cached")
+}
+
+func TestResolutionCacheZeroTTLBypassesTheCache(t *testing.T) {
+	t.Parallel()
+
+	cache, calls, fetch := newTestCache(t, 0)
+
+	_, err := cache.do(context.Background(), "key", fetch)
+	require.NoError(t, err)
+	_, err = cache.do(context.Background(), "key", fetch)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2), calls.Load(), "a zero TTL must disable caching")
+	assert.Empty(t, cache.entries)
+}
+
+func TestResolutionCacheStaysBounded(t *testing.T) {
+	t.Parallel()
+
+	cache, _, fetch := newTestCache(t, time.Minute)
+	cache.max = 8
+
+	for i := range 100 {
+		_, err := cache.do(context.Background(), strconv.Itoa(i), fetch)
+		require.NoError(t, err)
+	}
+
+	assert.LessOrEqual(t, len(cache.entries), cache.max)
+}
+
+func TestResolutionCacheEvictsExpiredEntriesFirst(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		cache, _, fetch := newTestCache(t, time.Minute)
+		cache.max = 4
+
+		for i := range cache.max {
+			_, err := cache.do(context.Background(), fmt.Sprintf("old-%d", i), fetch)
+			require.NoError(t, err)
+		}
+		require.Len(t, cache.entries, cache.max)
+
+		time.Sleep(2 * time.Minute)
+		_, err := cache.do(context.Background(), "fresh", fetch)
+		require.NoError(t, err)
+
+		assert.Len(t, cache.entries, 1, "the expired entries make room for the new one")
+		assert.Contains(t, cache.entries, "fresh")
+	})
+}
+
+func TestResolutionCacheReturnsACopy(t *testing.T) {
+	t.Parallel()
+
+	cache, _, fetch := newTestCache(t, time.Minute)
+
+	first, err := cache.do(context.Background(), "key", fetch)
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+	first[0] = "mutated"
+
+	second, err := cache.do(context.Background(), "key", fetch)
+	require.NoError(t, err)
+	assert.NotEqual(t, "mutated", second[0], "one caller must not be able to corrupt another's result")
+}
+
+// The fetch is shared by every waiter, so it must not inherit the cancellation
+// of whichever caller happened to start it. The cancelled caller itself gets
+// its cancellation back, but the fetch completes and fills the cache.
+func TestResolutionCacheDetachesCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		cache, _, _ := newTestCache(t, time.Minute)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		fetchErr := make(chan error, 1)
+		_, err := cache.do(ctx, "key", func(fetchCtx context.Context) ([]string, error) {
+			fetchErr <- fetchCtx.Err()
+			return []string{"served"}, nil
+		})
+		require.ErrorIs(t, err, context.Canceled, "a cancelled caller gets its cancellation, not the result")
+
+		// Wait runs the abandoned fetch to completion.
+		synctest.Wait()
+		require.NoError(t, <-fetchErr, "the fetch must not inherit the caller's cancellation")
+
+		value, ok := cache.get("key")
+		require.True(t, ok, "the detached fetch must still fill the cache")
+		assert.Equal(t, []string{"served"}, value)
+	})
+}
+
+// The shared fetch is detached from cancellation, but a waiter is not: a
+// cancelled caller returns immediately instead of blocking until the shared
+// fetch finishes.
+func TestResolutionCacheWaiterReturnsOnItsOwnCancellation(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		cache, _, _ := newTestCache(t, time.Minute)
+
+		release := make(chan struct{})
+		leaderDone := make(chan struct{})
+		go func() {
+			defer close(leaderDone)
+			_, err := cache.do(context.Background(), "key", func(context.Context) ([]string, error) {
+				<-release
+				return []string{"served"}, nil
+			})
+			assert.NoError(t, err)
+		}()
+		// The leader is inside the fetch once everything is blocked.
+		synctest.Wait()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		waiterErr := make(chan error, 1)
+		go func() {
+			_, err := cache.do(ctx, "key", func(context.Context) ([]string, error) {
+				return nil, errors.New("the waiter must join the in-flight fetch, not start its own")
+			})
+			waiterErr <- err
+		}()
+		// The waiter is parked in the shared flight.
+		synctest.Wait()
+
+		cancel()
+		require.ErrorIs(t, <-waiterErr, context.Canceled, "the waiter must observe its own cancellation while the fetch is still running")
+
+		close(release)
+		<-leaderDone
+	})
+}

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/util"
@@ -69,6 +70,10 @@ func (api *API) GetFilteredAssets(ctx context.Context, assetStrings []string, hi
 	if len(assetStrings) == 0 {
 		return assetUUIDSet, nil
 	}
+	// Callers pass the asset strings in map order, so sort them to keep the
+	// encoded query stable for a given asset set. The query doubles as the
+	// resolution cache key.
+	slices.Sort(assetStrings)
 
 	if util.CheckMinimumVersion(historianInfo, "8.1.0", false) {
 		uuids := make([]string, 0, len(assetStrings))

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -118,7 +118,7 @@ func batchPaths(paths []string) [][]string {
 func (api *API) collectAssetsByPath(ctx context.Context, set map[uuid.UUID]schemas.Asset, pathFilter string) error {
 	assetQuery := url.Values{}
 	assetQuery.Add("Path", pathFilter)
-	assets, err := api.GetAssets(ctx, assetQuery.Encode())
+	assets, err := api.GetAssetsCached(ctx, assetQuery.Encode())
 	if err != nil {
 		return err
 	}
@@ -154,10 +154,8 @@ func (api *API) GetFilteredAssets(ctx context.Context, assetStrings []string, hi
 
 		if len(uuids) > 0 {
 			assetQuery := url.Values{}
-			for i, u := range uuids {
-				assetQuery.Add(fmt.Sprintf("UUIDs[%d]", i), u)
-			}
-			assets, err := api.GetAssets(ctx, assetQuery.Encode())
+			util.AddSortedIndexedParams(assetQuery, "UUIDs", uuids)
+			assets, err := api.GetAssetsCached(ctx, assetQuery.Encode())
 			if err != nil {
 				return nil, err
 			}
@@ -200,7 +198,7 @@ func (api *API) GetFilteredAssets(ctx context.Context, assetStrings []string, hi
 		}
 		assetQuery := url.Values{}
 		assetQuery.Add(searchKey, assetString)
-		assets, err := api.GetAssets(ctx, assetQuery.Encode())
+		assets, err := api.GetAssetsCached(ctx, assetQuery.Encode())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -6,7 +6,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/util"
@@ -62,6 +64,70 @@ func (e *HTTPError) Error() string {
 	return http.StatusText(e.StatusCode) + ": " + e.Body
 }
 
+// pathBatchBudget caps the percent-encoded size of one batched Path filter, so
+// the request URL stays well inside the length limit of any proxy in front of
+// the historian. The boundary is bytes rather than a path count: escaping and
+// percent-encoding can triple a path full of backslashes.
+const pathBatchBudget = 4096
+
+// isPathRegex reports whether the historian reads an asset string as a regular
+// expression instead of an exact asset path. It mirrors the historian's own
+// check: a value wrapped in slashes is a regex.
+func isPathRegex(assetString string) bool {
+	return len(assetString) >= 2 && strings.HasPrefix(assetString, "/") && strings.HasSuffix(assetString, "/")
+}
+
+// pathAlternation builds a Path filter that matches every given literal asset
+// path and nothing else. The historian applies the value as an unanchored
+// POSIX regex over asset_path, so the alternation carries its own anchors.
+// Asset paths are backslash-separated and asset names may contain regex
+// metacharacters, so every path is escaped first. regexp.QuoteMeta escapes only
+// non-alphanumerics, which a POSIX ARE reads as literals just like Go does.
+func pathAlternation(paths []string) string {
+	escaped := make([]string, 0, len(paths))
+	for _, path := range paths {
+		escaped = append(escaped, regexp.QuoteMeta(path))
+	}
+	return "/^(" + strings.Join(escaped, "|") + ")$/"
+}
+
+// batchPaths splits literal asset paths into batches whose alternation stays
+// within pathBatchBudget once percent-encoded. A path that exceeds the budget
+// on its own forms a batch of one.
+func batchPaths(paths []string) [][]string {
+	var batches [][]string
+	batch := make([]string, 0, len(paths))
+	size := 0
+	for _, path := range paths {
+		// The alternation separator | encodes to %7C.
+		cost := len(url.QueryEscape(regexp.QuoteMeta(path))) + len("%7C")
+		if len(batch) > 0 && size+cost > pathBatchBudget {
+			batches = append(batches, batch)
+			batch, size = nil, 0
+		}
+		batch = append(batch, path)
+		size += cost
+	}
+	if len(batch) > 0 {
+		batches = append(batches, batch)
+	}
+	return batches
+}
+
+// collectAssetsByPath adds every asset matching the given Path filter to set.
+func (api *API) collectAssetsByPath(ctx context.Context, set map[uuid.UUID]schemas.Asset, pathFilter string) error {
+	assetQuery := url.Values{}
+	assetQuery.Add("Path", pathFilter)
+	assets, err := api.GetAssets(ctx, assetQuery.Encode())
+	if err != nil {
+		return err
+	}
+	for _, asset := range assets {
+		set[asset.UUID] = asset
+	}
+	return nil
+}
+
 // GetFilteredAssets returns a map of assets that match the given asset strings
 func (api *API) GetFilteredAssets(ctx context.Context, assetStrings []string, historianInfo *schemas.HistorianInfo) (map[uuid.UUID]schemas.Asset, error) {
 	assetUUIDSet := map[uuid.UUID]schemas.Asset{}
@@ -100,15 +166,28 @@ func (api *API) GetFilteredAssets(ctx context.Context, assetStrings []string, hi
 			}
 		}
 
+		// The historian rebuilds the full asset-path tree for every Path
+		// request, so batch the literal paths into a single alternation. A
+		// user-supplied regex keeps its own request: its content must not be
+		// escaped and it stays unanchored.
+		literals := make([]string, 0, len(paths))
 		for _, path := range paths {
-			assetQuery := url.Values{}
-			assetQuery.Add("Path", path)
-			assets, err := api.GetAssets(ctx, assetQuery.Encode())
-			if err != nil {
-				return nil, err
+			if isPathRegex(path) {
+				if err := api.collectAssetsByPath(ctx, assetUUIDSet, path); err != nil {
+					return nil, err
+				}
+				continue
 			}
-			for _, asset := range assets {
-				assetUUIDSet[asset.UUID] = asset
+			literals = append(literals, path)
+		}
+		for _, batch := range batchPaths(literals) {
+			// A single path stays an exact match, which skips the regex engine.
+			pathFilter := batch[0]
+			if len(batch) > 1 {
+				pathFilter = pathAlternation(batch)
+			}
+			if err := api.collectAssetsByPath(ctx, assetUUIDSet, pathFilter); err != nil {
+				return nil, err
 			}
 		}
 		return assetUUIDSet, nil

--- a/pkg/api/util_internal_test.go
+++ b/pkg/api/util_internal_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short paths stay in one batch", func(t *testing.T) {
+		t.Parallel()
+
+		paths := []string{`plant\line 1`, `plant\line 2`, `plant\line 3`}
+		batches := batchPaths(paths)
+
+		require.Len(t, batches, 1)
+		assert.Equal(t, paths, batches[0])
+	})
+
+	t.Run("batches stay within the budget once encoded", func(t *testing.T) {
+		t.Parallel()
+
+		paths := make([]string, 200)
+		for i := range paths {
+			paths[i] = fmt.Sprintf(`plant\area %03d\line %03d\unit %03d`, i, i, i)
+		}
+		batches := batchPaths(paths)
+		require.Greater(t, len(batches), 1, "this many paths must not fit in one batch")
+
+		// The anchors around the alternation are the only cost the batch
+		// budget does not account for.
+		anchors := len(url.QueryEscape("/^()$/"))
+		total := 0
+		for _, batch := range batches {
+			encoded := len(url.QueryEscape(pathAlternation(batch)))
+			assert.LessOrEqual(t, encoded, pathBatchBudget+anchors, "an encoded filter must stay within the budget")
+			total += len(batch)
+		}
+		assert.Equal(t, len(paths), total, "no path may be dropped")
+	})
+
+	t.Run("a path over the budget forms a batch of one", func(t *testing.T) {
+		t.Parallel()
+
+		long := strings.Repeat(`segment\`, 1000) + "leaf"
+		batches := batchPaths([]string{`plant\line 1`, long, `plant\line 2`})
+
+		assert.Equal(t, [][]string{{`plant\line 1`}, {long}, {`plant\line 2`}}, batches)
+	})
+}

--- a/pkg/api/util_test.go
+++ b/pkg/api/util_test.go
@@ -265,6 +265,27 @@ func TestGetFilteredAssets(t *testing.T) {
 		)
 		assert.Equal(t, "site/a2", (*requests)[1].query.Get("Path"))
 	})
+
+	// Callers build the asset strings from a map (the event handler collects
+	// missing parent asset UUIDs that way), so the input order varies between
+	// otherwise identical calls. The encoded query is the resolution cache key,
+	// so the same asset set has to encode to the same string every time.
+	t.Run("encodes the same asset set identically whatever order the caller supplies", func(t *testing.T) {
+		t.Parallel()
+		srv, requests := startServer(t)
+		client := newClient(t, srv.URL)
+
+		info := &schemas.HistorianInfo{Version: "v8.1.0"}
+		_, err := client.GetFilteredAssets(context.Background(),
+			[]string{a3UUID.String(), a1UUID.String(), a2UUID.String()}, info)
+		require.NoError(t, err)
+		_, err = client.GetFilteredAssets(context.Background(),
+			[]string{a2UUID.String(), a3UUID.String(), a1UUID.String()}, info)
+		require.NoError(t, err)
+
+		require.Len(t, *requests, 2)
+		assert.Equal(t, (*requests)[0].rawQuery, (*requests)[1].rawQuery)
+	})
 }
 
 func TestGetAssets(t *testing.T) {

--- a/pkg/api/util_test.go
+++ b/pkg/api/util_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -101,11 +103,6 @@ func TestGetFilteredAssets(t *testing.T) {
 		a2UUID.String(): a2,
 		a3UUID.String(): a3,
 	}
-	byPath := map[string]schemas.Asset{
-		a1.AssetPath: a1,
-		a2.AssetPath: a2,
-		a3.AssetPath: a3,
-	}
 	allAssets := []schemas.Asset{a1, a2, a3}
 
 	type recordedRequest struct {
@@ -139,9 +136,7 @@ func TestGetFilteredAssets(t *testing.T) {
 					matched = append(matched, a)
 				}
 			case q.Get("Path") != "":
-				if a, ok := byPath[q.Get("Path")]; ok {
-					matched = append(matched, a)
-				}
+				matched = matchPath(t, allAssets, q.Get("Path"))
 			default:
 				matched = allAssets
 			}
@@ -158,7 +153,7 @@ func TestGetFilteredAssets(t *testing.T) {
 		return c
 	}
 
-	t.Run("v8.1.0 batches uuids and queries paths individually", func(t *testing.T) {
+	t.Run("v8.1.0 sends uuids and paths as separate requests", func(t *testing.T) {
 		t.Parallel()
 		srv, requests := startServer(t)
 		client := newClient(t, srv.URL)
@@ -171,7 +166,7 @@ func TestGetFilteredAssets(t *testing.T) {
 		assert.Contains(t, result, a2UUID)
 		assert.Contains(t, result, a3UUID)
 
-		require.Len(t, *requests, 2, "expected one batched UUIDs request followed by one path request")
+		require.Len(t, *requests, 2, "expected one UUIDs request followed by one path request")
 		assert.ElementsMatch(t,
 			[]string{a1UUID.String(), a3UUID.String()},
 			indexedQuery((*requests)[0].query, "UUIDs"),
@@ -194,11 +189,9 @@ func TestGetFilteredAssets(t *testing.T) {
 		assert.Contains(t, result, a1UUID)
 		assert.Contains(t, result, a3UUID)
 
-		require.Len(t, *requests, 2)
-		for _, req := range *requests {
-			assert.Empty(t, indexedQuery(req.query, "UUIDs"), "no UUIDs[i] should be sent when input has no uuids")
-			assert.NotEmpty(t, req.query.Get("Path"))
-		}
+		require.Len(t, *requests, 1, "two paths and no uuids means one batched path request")
+		assert.Empty(t, indexedQuery((*requests)[0].query, "UUIDs"), "no UUIDs[i] should be sent when input has no uuids")
+		assert.NotEmpty(t, (*requests)[0].query.Get("Path"))
 	})
 
 	t.Run("v7.x issues per-asset Keyword/Path requests", func(t *testing.T) {
@@ -390,6 +383,30 @@ func TestClientIdentificationHeaders(t *testing.T) {
 }
 
 // indexedQuery returns values for the indexed parameter form Foo[0]=a&Foo[1]=b in input order.
+// matchPath models how the historian applies the Path asset filter: a value
+// wrapped in slashes is an unanchored regular expression over asset_path,
+// anything else is an exact match.
+func matchPath(t *testing.T, assets []schemas.Asset, path string) []schemas.Asset {
+	t.Helper()
+	var matched []schemas.Asset
+	if len(path) >= 2 && strings.HasPrefix(path, "/") && strings.HasSuffix(path, "/") {
+		pattern, err := regexp.Compile(path[1 : len(path)-1])
+		require.NoError(t, err, "the historian would reject this pattern")
+		for _, asset := range assets {
+			if pattern.MatchString(asset.AssetPath) {
+				matched = append(matched, asset)
+			}
+		}
+		return matched
+	}
+	for _, asset := range assets {
+		if asset.AssetPath == path {
+			matched = append(matched, asset)
+		}
+	}
+	return matched
+}
+
 func indexedQuery(q url.Values, prefix string) []string {
 	var out []string
 	for i := 0; ; i++ {
@@ -450,4 +467,114 @@ func TestHTTPErrorCarriesErrorSource(t *testing.T) {
 			assert.Equal(t, !testCase.isDownstream, backend.IsPluginError(err), "error source attribution")
 		})
 	}
+}
+
+// startPathServer serves assets filtered with the historian's Path semantics
+// and returns a client against it plus an accessor for the recorded queries.
+func startPathServer(t *testing.T, assets []schemas.Asset) (client *api.API, recorded func() []url.Values) {
+	t.Helper()
+
+	var (
+		mu       sync.Mutex
+		requests []url.Values
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.URL.Query())
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(matchPath(t, assets, r.URL.Query().Get("Path")))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := api.NewAPIWithToken(srv.URL, "tok", "org")
+	require.NoError(t, err)
+
+	recorded = func() []url.Values {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(requests)
+	}
+	return client, recorded
+}
+
+// One request per path makes a panel that addresses its assets by path fan out
+// into N requests, and the historian rebuilds the whole asset-path tree for
+// each one. The Path filter accepts a regex, so the literal paths belong in a
+// single anchored alternation.
+func TestGetFilteredAssetsBatchesPaths(t *testing.T) {
+	t.Parallel()
+
+	// Asset paths are backslash-separated and asset names may contain regex
+	// metacharacters, so every literal has to be escaped before it goes into
+	// the alternation.
+	mixer := schemas.Asset{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "mixer (A)"}, AssetPath: `plant\line 1\mixer (A)`}
+	pump := schemas.Asset{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "pump.1"}, AssetPath: `plant\line 2\pump.1`}
+	oven := schemas.Asset{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "oven+3"}, AssetPath: `plant\line 3\oven+3`}
+	// decoy is matched by an unescaped "pump.1" pattern but not by an escaped one.
+	decoy := schemas.Asset{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "pumpX1"}, AssetPath: `plant\line 2\pumpX1`}
+	allAssets := []schemas.Asset{mixer, pump, oven, decoy}
+
+	client, recorded := startPathServer(t, allAssets)
+
+	info := &schemas.HistorianInfo{Version: "v8.1.0"}
+	result, err := client.GetFilteredAssets(context.Background(),
+		[]string{mixer.AssetPath, pump.AssetPath, oven.AssetPath}, info)
+	require.NoError(t, err)
+
+	require.Len(t, recorded(), 1, "the literal paths must collapse into one request")
+	assert.Len(t, result, 3)
+	assert.Contains(t, result, mixer.UUID)
+	assert.Contains(t, result, pump.UUID)
+	assert.Contains(t, result, oven.UUID)
+	assert.NotContains(t, result, decoy.UUID, "regex metacharacters in a path must be escaped")
+}
+
+// A user-supplied regex is not a literal, so it must not be escaped and its
+// unanchored semantics must survive. Only the literal paths get batched.
+func TestGetFilteredAssetsKeepsUserRegexSeparate(t *testing.T) {
+	t.Parallel()
+
+	line1 := schemas.Asset{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "mixer"}, AssetPath: `plant\line 1\mixer`}
+	line2 := schemas.Asset{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "mixer"}, AssetPath: `plant\line 2\mixer`}
+	other := schemas.Asset{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "pump"}, AssetPath: `plant\line 3\pump`}
+	allAssets := []schemas.Asset{line1, line2, other}
+
+	client, recorded := startPathServer(t, allAssets)
+
+	info := &schemas.HistorianInfo{Version: "v8.1.0"}
+	result, err := client.GetFilteredAssets(context.Background(),
+		[]string{`/mixer$/`, other.AssetPath}, info)
+	require.NoError(t, err)
+
+	require.Len(t, recorded(), 2, "a user regex keeps its own request, the literal path is batched separately")
+	assert.Len(t, result, 3)
+	assert.Contains(t, result, line1.UUID, "the user regex must stay unanchored and unescaped")
+	assert.Contains(t, result, line2.UUID)
+	assert.Contains(t, result, other.UUID)
+}
+
+// A very long alternation would push the encoded URL past the limit of a proxy
+// in front of the historian, so the literal paths are batched by encoded size.
+func TestGetFilteredAssetsKeepsPathBatchesWithinTheBudget(t *testing.T) {
+	t.Parallel()
+
+	const pathCount = 400
+	assets := make([]schemas.Asset, 0, pathCount)
+	paths := make([]string, 0, pathCount)
+	for i := range pathCount {
+		path := fmt.Sprintf(`plant\area %03d\line %03d`, i/10, i)
+		assets = append(assets, schemas.Asset{
+			BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: fmt.Sprintf("line %03d", i)},
+			AssetPath: path,
+		})
+		paths = append(paths, path)
+	}
+
+	client, recorded := startPathServer(t, assets)
+
+	result, err := client.GetFilteredAssets(context.Background(), paths, &schemas.HistorianInfo{Version: "v8.1.0"})
+	require.NoError(t, err)
+
+	assert.Len(t, result, pathCount, "batching must not drop any asset")
+	assert.Greater(t, len(recorded()), 1, "the alternation must be split into multiple requests")
 }

--- a/pkg/datasource/event_query_handler.go
+++ b/pkg/datasource/event_query_handler.go
@@ -102,11 +102,8 @@ func (ds *HistorianDataSource) handleEventQuery(ctx context.Context, eventQuery 
 	}
 
 	eventTypeQuery := url.Values{}
-	i := 0
-	for eventTypeUUID := range eventTypeUUIDs {
-		eventTypeQuery.Add(fmt.Sprintf("EventTypeUUIDs[%d]", i), eventTypeUUID.String())
-		i++
-	}
+	// Sorted so the encoded query is stable for a given event-type set.
+	util.AddSortedIndexedUUIDs(eventTypeQuery, "EventTypeUUIDs", eventTypeUUIDs)
 	if eventQuery.Type == string(schemas.EventTypePropertyTypeSimple) {
 		eventTypeQuery.Add("Types[0]", eventQuery.Type)
 	}
@@ -136,7 +133,7 @@ func (ds *HistorianDataSource) handleEventQuery(ctx context.Context, eventQuery 
 			AssetProperties: eventQuery.AssetProperties,
 			Options:         *eventQuery.Options,
 		}
-		assetProperties, err := ds.API.GetAssetProperties(ctx, "")
+		assetProperties, err := ds.API.GetAssetPropertiesCached(ctx, "")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/datasource/health.go
+++ b/pkg/datasource/health.go
@@ -12,7 +12,9 @@ const (
 	SuccessfulHealthCheckMessage string = "Connection test successful, %v timeseries database(s) found"
 )
 
-// CheckHealth checks the health by fetching the time series databases
+// CheckHealth checks the health by fetching the time series databases. It uses
+// the uncached call on purpose: a health check has to reach the historian, or a
+// broken connection would keep reporting the last cached result.
 func (ds *HistorianDataSource) CheckHealth(ctx context.Context, _ *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	databases, err := ds.API.GetTimeseriesDatabases(ctx, "")
 	if err != nil {

--- a/pkg/datasource/historian.go
+++ b/pkg/datasource/historian.go
@@ -82,6 +82,12 @@ func NewDataSource(_ context.Context, s backend.DataSourceInstanceSettings) (ins
 	if seconds, err := strconv.Atoi(settings.QueryTimeout); err == nil && seconds > 0 {
 		apiOptions.QueryTimeout = time.Duration(seconds) * time.Second
 	}
+	// A zero TTL disables the resolution caches. LoadSettings guarantees the
+	// value parses as a non-negative number of seconds that fits in a
+	// time.Duration.
+	if seconds, err := strconv.Atoi(settings.ResolutionCacheTTL); err == nil && seconds > 0 {
+		apiOptions.ResolutionCacheTTL = time.Duration(seconds) * time.Second
+	}
 	historianDataSource.API, err = api.NewAPIWithOptions(apiOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/api"
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/util"
 	"github.com/google/uuid"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -189,23 +190,15 @@ func (ds *HistorianDataSource) handleAssetMeasurementQuery(ctx context.Context, 
 
 	assetPropertyQuery := url.Values{}
 
-	// Sort the UUIDs so the same asset set always encodes to the same query.
 	// Map iteration order is random and the query doubles as the resolution
-	// cache key.
-	assetUUIDs := make([]string, 0, len(assets))
-	for assetUUID := range assets {
-		assetUUIDs = append(assetUUIDs, assetUUID.String())
-	}
-	slices.Sort(assetUUIDs)
-	for i, assetUUID := range assetUUIDs {
-		assetPropertyQuery.Add(fmt.Sprintf("AssetUUIDs[%d]", i), assetUUID)
-	}
+	// cache key, so the UUIDs go in sorted.
+	util.AddSortedIndexedUUIDs(assetPropertyQuery, "AssetUUIDs", assets)
 
 	for i, datatype := range assetMeasurementQuery.Options.Datatypes {
 		assetPropertyQuery.Add(fmt.Sprintf("Datatypes[%d]", i), datatype)
 	}
 
-	assetProperties, err := ds.API.GetAssetProperties(ctx, assetPropertyQuery.Encode())
+	assetProperties, err := ds.API.GetAssetPropertiesCached(ctx, assetPropertyQuery.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +268,7 @@ func (ds *HistorianDataSource) getMeasurements(ctx context.Context, measurementQ
 			measurements = append(measurements, measurementQuery.Measurement)
 		}
 	}
-	databases, err := ds.API.GetTimeseriesDatabases(ctx, "")
+	databases, err := ds.API.GetTimeseriesDatabasesCached(ctx, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -189,8 +189,16 @@ func (ds *HistorianDataSource) handleAssetMeasurementQuery(ctx context.Context, 
 
 	assetPropertyQuery := url.Values{}
 
-	for i, assetUUID := range slices.Collect(maps.Keys(assets)) {
-		assetPropertyQuery.Add(fmt.Sprintf("AssetUUIDs[%d]", i), assetUUID.String())
+	// Sort the UUIDs so the same asset set always encodes to the same query.
+	// Map iteration order is random and the query doubles as the resolution
+	// cache key.
+	assetUUIDs := make([]string, 0, len(assets))
+	for assetUUID := range assets {
+		assetUUIDs = append(assetUUIDs, assetUUID.String())
+	}
+	slices.Sort(assetUUIDs)
+	for i, assetUUID := range assetUUIDs {
+		assetPropertyQuery.Add(fmt.Sprintf("AssetUUIDs[%d]", i), assetUUID)
 	}
 
 	for i, datatype := range assetMeasurementQuery.Options.Datatypes {

--- a/pkg/datasource/query_handler.go
+++ b/pkg/datasource/query_handler.go
@@ -287,6 +287,14 @@ func (ds *HistorianDataSource) getMeasurements(ctx context.Context, measurementQ
 			}
 		}
 
+		// A requested database filter that resolves to nothing must yield no
+		// measurements. Searching without the constraint would match every
+		// database, e.g. while the cached database list does not yet hold a
+		// just-created database.
+		if len(measurementQuery.Databases) > 0 && len(databaseUUIDs) == 0 {
+			continue
+		}
+
 		measurementsQuery := url.Values{}
 		measurementsQuery.Set("Keyword", measurement)
 		// a non-positive seriesLimit means unlimited, don't ask the API to truncate

--- a/pkg/datasource/query_handler_test.go
+++ b/pkg/datasource/query_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -438,4 +439,59 @@ func TestCheckHealthAlwaysReachesTheHistorian(t *testing.T) {
 	}
 
 	assert.Len(t, recorder.queriesFor("/api/timeseries-databases"), 3, "the health check must not be cached")
+}
+
+// A measurement query filtered on a database name that resolves to nothing must
+// return no measurements. Dropping the filter instead would search every
+// database, and with the resolution cache a just-created database stays
+// unresolvable for up to the TTL.
+func TestGetMeasurementsWithUnresolvableDatabaseFilterReturnsNothing(t *testing.T) {
+	t.Parallel()
+
+	factory := schemas.TimeseriesDatabase{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "factory"}}
+	measurement := schemas.Measurement{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "temperature"}}
+
+	newFixture := func(t *testing.T) (*HistorianDataSource, *requestRecorder) {
+		t.Helper()
+		recorder := &requestRecorder{}
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/timeseries-databases", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode([]schemas.TimeseriesDatabase{factory})
+		})
+		mux.HandleFunc("GET /api/measurements", func(w http.ResponseWriter, r *http.Request) {
+			recorder.record(r.URL.Path, r.URL.RawQuery)
+			_ = json.NewEncoder(w).Encode([]schemas.Measurement{measurement})
+		})
+		return newFakeHistorianDataSource(t, mux), recorder
+	}
+
+	t.Run("an unresolvable name yields no measurements and no search", func(t *testing.T) {
+		t.Parallel()
+		ds, recorder := newFixture(t)
+		measurements, err := ds.getMeasurements(t.Context(), schemas.MeasurementQuery{
+			Measurement: "temperature",
+			Databases:   []string{"just-created"},
+		}, 50)
+		require.NoError(t, err)
+
+		assert.Empty(t, measurements, "a database filter that resolves to nothing must not match any measurement")
+		assert.Empty(t, recorder.queriesFor("/api/measurements"), "the search must not go out without the database filter")
+	})
+
+	t.Run("a resolvable name keeps its filter", func(t *testing.T) {
+		t.Parallel()
+		ds, recorder := newFixture(t)
+		measurements, err := ds.getMeasurements(t.Context(), schemas.MeasurementQuery{
+			Measurement: "temperature",
+			Databases:   []string{"factory"},
+		}, 50)
+		require.NoError(t, err)
+
+		require.Equal(t, []string{measurement.UUID.String()}, measurements)
+		queries := recorder.queriesFor("/api/measurements")
+		require.Len(t, queries, 1)
+		parsed, err := url.ParseQuery(queries[0])
+		require.NoError(t, err)
+		assert.Equal(t, factory.UUID.String(), parsed.Get("DatabaseUUIDs[0]"), "the resolved filter must reach the historian")
+	})
 }

--- a/pkg/datasource/query_handler_test.go
+++ b/pkg/datasource/query_handler_test.go
@@ -3,6 +3,7 @@ package datasource
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -196,5 +197,44 @@ func TestQueryDataAttributesHistorianErrorsToDownstream(t *testing.T) {
 			assert.Equal(t, testCase.expectedStatus, dataResponse.Status, "the historian status code must be forwarded")
 			assert.Equal(t, backend.ErrorSourceDownstream, dataResponse.ErrorSource, "a historian failure is not a plugin failure")
 		})
+	}
+}
+
+// handleAssetMeasurementQuery builds the asset-property query from a map of
+// assets, so its AssetUUIDs[i] order is random unless the UUIDs are sorted
+// first. The encoded query is the resolution cache key, so an unstable order
+// makes a repeat of the same panel query miss the cache.
+func TestAssetMeasurementQueryEncodesAssetUUIDsInAStableOrder(t *testing.T) {
+	t.Parallel()
+
+	const assetCount = 6
+	assets := make([]schemas.Asset, 0, assetCount)
+	properties := make([]schemas.AssetProperty, 0, assetCount)
+	for i := range assetCount {
+		assetUUID := uuid.New()
+		assets = append(assets, schemas.Asset{
+			BaseModel: schemas.BaseModel{UUID: assetUUID, Name: fmt.Sprintf("asset-%d", i)},
+			AssetPath: fmt.Sprintf("plant\\asset-%d", i),
+		})
+		properties = append(properties, schemas.AssetProperty{
+			BaseModel:       schemas.BaseModel{UUID: uuid.New(), Name: "temperature"},
+			AssetUUID:       assetUUID,
+			MeasurementUUID: uuid.New(),
+		})
+	}
+
+	ds, recorder := multiAssetQueryFixture(t, assets, properties)
+	timeRange := backend.TimeRange{From: time.Unix(0, 0).UTC(), To: time.Unix(3600, 0).UTC()}
+	for range 20 {
+		_, err := ds.handleAssetMeasurementQuery(context.Background(), schemas.AssetMeasurementQuery{
+			Assets: []string{"plant"},
+		}, timeRange, time.Minute, 0, &schemas.HistorianInfo{Version: "v8.1.0"})
+		require.NoError(t, err)
+	}
+
+	queries := recorder.queriesFor("/api/asset-properties")
+	require.Len(t, queries, 20)
+	for i := range queries {
+		require.Equal(t, queries[0], queries[i], "every repeat of the same query must encode to the same string")
 	}
 }

--- a/pkg/datasource/query_handler_test.go
+++ b/pkg/datasource/query_handler_test.go
@@ -5,12 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
 	"github.com/google/uuid"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -223,7 +227,7 @@ func TestAssetMeasurementQueryEncodesAssetUUIDsInAStableOrder(t *testing.T) {
 		})
 	}
 
-	ds, recorder := multiAssetQueryFixture(t, assets, properties)
+	ds, recorder := multiAssetQueryFixture(t, assets, properties, 0)
 	timeRange := backend.TimeRange{From: time.Unix(0, 0).UTC(), To: time.Unix(3600, 0).UTC()}
 	for range 20 {
 		_, err := ds.handleAssetMeasurementQuery(context.Background(), schemas.AssetMeasurementQuery{
@@ -237,4 +241,201 @@ func TestAssetMeasurementQueryEncodesAssetUUIDsInAStableOrder(t *testing.T) {
 	for i := range queries {
 		require.Equal(t, queries[0], queries[i], "every repeat of the same query must encode to the same string")
 	}
+}
+
+// A dashboard refresh must not re-resolve asset properties it already resolved.
+// Only the timeseries query, whose time window actually changes, still reaches
+// the historian.
+func TestAssetMeasurementQueryServesRepeatedResolutionFromCache(t *testing.T) {
+	t.Parallel()
+
+	assetUUID := uuid.New()
+	measurementUUID := uuid.New()
+	assets := []schemas.Asset{{
+		BaseModel: schemas.BaseModel{UUID: assetUUID, Name: "mixer"},
+		AssetPath: `plant\line 1\mixer`,
+	}}
+	properties := []schemas.AssetProperty{{
+		BaseModel:       schemas.BaseModel{UUID: uuid.New(), Name: "temperature"},
+		AssetUUID:       assetUUID,
+		MeasurementUUID: measurementUUID,
+	}}
+
+	ds, recorder := multiAssetQueryFixture(t, assets, properties, time.Minute)
+	query := schemas.AssetMeasurementQuery{
+		Assets:          []string{`plant\line 1\mixer`},
+		AssetProperties: []string{"temperature"},
+	}
+	timeRange := backend.TimeRange{From: time.Unix(0, 0).UTC(), To: time.Unix(3600, 0).UTC()}
+
+	first, err := ds.handleAssetMeasurementQuery(context.Background(), query, timeRange, time.Minute, 0, &schemas.HistorianInfo{Version: "v8.1.0"})
+	require.NoError(t, err)
+	second, err := ds.handleAssetMeasurementQuery(context.Background(), query, timeRange, time.Minute, 0, &schemas.HistorianInfo{Version: "v8.1.0"})
+	require.NoError(t, err)
+
+	assert.Len(t, recorder.queriesFor("/api/assets"), 1, "the asset lookup must be served from the cache on the repeat")
+	assert.Len(t, recorder.queriesFor("/api/asset-properties"), 1, "the resolution must not reach the historian twice")
+	assert.Len(t, recorder.queriesFor("/api/timeseries/query"), 2, "the timeseries query itself is never cached")
+
+	require.Len(t, first, 1)
+	require.Len(t, second, 1)
+	assert.Equal(t, first[0].Name, second[0].Name, "a cached resolution must produce the same frames")
+	assert.Equal(t, first[0].Rows(), second[0].Rows())
+}
+
+// A cold dashboard load is many panels resolving the same assets at once. They
+// share one resolution request instead of one per panel.
+func TestAssetMeasurementQueryCollapsesConcurrentPanelResolutions(t *testing.T) {
+	t.Parallel()
+
+	assetUUID := uuid.New()
+	assets := []schemas.Asset{{
+		BaseModel: schemas.BaseModel{UUID: assetUUID, Name: "mixer"},
+		AssetPath: "mixer",
+	}}
+	properties := []schemas.AssetProperty{{
+		BaseModel:       schemas.BaseModel{UUID: uuid.New(), Name: "temperature"},
+		AssetUUID:       assetUUID,
+		MeasurementUUID: uuid.New(),
+	}}
+
+	// The resolution is held open for the whole test, so a panel that fails to
+	// join the in-flight request has to issue its own and be counted. A slow
+	// scheduler can only delay a panel, so this cannot fail spuriously.
+	release := make(chan struct{})
+	resolutions := &atomic.Int64{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/assets", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, assets)
+	})
+	mux.HandleFunc("GET /api/asset-properties", func(w http.ResponseWriter, _ *http.Request) {
+		resolutions.Add(1)
+		<-release
+		writeJSON(w, properties)
+	})
+	mux.HandleFunc("POST /api/timeseries/query", func(w http.ResponseWriter, r *http.Request) {
+		query := schemas.Query{}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&query))
+		frames := make(data.Frames, 0, len(query.MeasurementUUIDs))
+		for _, measurementUUID := range query.MeasurementUUIDs {
+			frames = append(frames, measurementFrame(measurementUUID, 2))
+		}
+		writeArrowResponse(t, w, frames)
+	})
+	ds := newFakeHistorianDataSourceWithTTL(t, mux, time.Minute)
+
+	query := schemas.AssetMeasurementQuery{Assets: []string{"mixer"}}
+	timeRange := backend.TimeRange{From: time.Unix(0, 0).UTC(), To: time.Unix(3600, 0).UTC()}
+
+	const panels = 12
+	done := sync.WaitGroup{}
+	done.Add(panels)
+	for range panels {
+		go func() {
+			defer done.Done()
+			_, err := ds.handleAssetMeasurementQuery(context.Background(), query, timeRange, time.Minute, 0, &schemas.HistorianInfo{Version: "v8.1.0"})
+			assert.NoError(t, err)
+		}()
+	}
+
+	require.Eventually(t, func() bool { return resolutions.Load() >= 1 }, time.Second, time.Millisecond,
+		"no panel ever reached the resolution")
+	assert.Never(t, func() bool { return resolutions.Load() > 1 }, 200*time.Millisecond, 5*time.Millisecond,
+		"a cold dashboard load must resolve once, not once per panel")
+
+	close(release)
+	done.Wait()
+
+	assert.Equal(t, int64(1), resolutions.Load())
+}
+
+// Reconfiguring an asset must reach dashboards once the TTL passes. The TTL is
+// the documented bound on how long a stale measurement can be served.
+func TestAssetMeasurementQueryPicksUpReconfiguredAssetAfterTTL(t *testing.T) {
+	t.Parallel()
+
+	assetUUID := uuid.New()
+	oldMeasurementUUID := uuid.New()
+	newMeasurementUUID := uuid.New()
+
+	var (
+		mu         sync.Mutex
+		properties = []schemas.AssetProperty{{
+			BaseModel:       schemas.BaseModel{UUID: uuid.New(), Name: "temperature"},
+			AssetUUID:       assetUUID,
+			MeasurementUUID: oldMeasurementUUID,
+		}}
+		queried []string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/assets", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, []schemas.Asset{{
+			BaseModel: schemas.BaseModel{UUID: assetUUID, Name: "mixer"},
+			AssetPath: "mixer",
+		}})
+	})
+	mux.HandleFunc("GET /api/asset-properties", func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		current := slices.Clone(properties)
+		mu.Unlock()
+		writeJSON(w, current)
+	})
+	mux.HandleFunc("POST /api/timeseries/query", func(w http.ResponseWriter, r *http.Request) {
+		query := schemas.Query{}
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&query))
+		mu.Lock()
+		queried = append(queried, query.MeasurementUUIDs...)
+		mu.Unlock()
+		frames := make(data.Frames, 0, len(query.MeasurementUUIDs))
+		for _, measurementUUID := range query.MeasurementUUIDs {
+			frames = append(frames, measurementFrame(measurementUUID, 2))
+		}
+		writeArrowResponse(t, w, frames)
+	})
+
+	// A short TTL keeps the test fast. The cache unit tests cover expiry on a
+	// fake clock; this one checks the reconfigured measurement reaches the panel.
+	const ttl = 20 * time.Millisecond
+	ds := newFakeHistorianDataSourceWithTTL(t, mux, ttl)
+	query := schemas.AssetMeasurementQuery{Assets: []string{"mixer"}}
+	timeRange := backend.TimeRange{From: time.Unix(0, 0).UTC(), To: time.Unix(3600, 0).UTC()}
+
+	_, err := ds.handleAssetMeasurementQuery(context.Background(), query, timeRange, time.Minute, 0, &schemas.HistorianInfo{Version: "v8.1.0"})
+	require.NoError(t, err)
+
+	mu.Lock()
+	properties[0].MeasurementUUID = newMeasurementUUID
+	mu.Unlock()
+
+	time.Sleep(20 * ttl)
+	_, err = ds.handleAssetMeasurementQuery(context.Background(), query, timeRange, time.Minute, 0, &schemas.HistorianInfo{Version: "v8.1.0"})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{oldMeasurementUUID.String(), newMeasurementUUID.String()}, queried,
+		"the second refresh must query the reconfigured measurement")
+}
+
+// A health check reports whether the historian is reachable right now, so it
+// must never be served from the cache.
+func TestCheckHealthAlwaysReachesTheHistorian(t *testing.T) {
+	t.Parallel()
+
+	recorder := &requestRecorder{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/timeseries-databases", func(w http.ResponseWriter, r *http.Request) {
+		recorder.record(r.URL.Path, r.URL.RawQuery)
+		writeJSON(w, []schemas.TimeseriesDatabase{{BaseModel: schemas.BaseModel{UUID: uuid.New(), Name: "factory"}}})
+	})
+	ds := newFakeHistorianDataSourceWithTTL(t, mux, time.Minute)
+
+	for range 3 {
+		result, err := ds.CheckHealth(context.Background(), &backend.CheckHealthRequest{})
+		require.NoError(t, err)
+		require.Equal(t, backend.HealthStatusOk, result.Status)
+	}
+
+	assert.Len(t, recorder.queriesFor("/api/timeseries-databases"), 3, "the health check must not be cached")
 }

--- a/pkg/datasource/resource_handler.go
+++ b/pkg/datasource/resource_handler.go
@@ -95,15 +95,15 @@ func (ds *HistorianDataSource) handleGetCollectors(_ http.ResponseWriter, req *h
 }
 
 func (ds *HistorianDataSource) handleGetDatabases(_ http.ResponseWriter, req *http.Request) (interface{}, error) {
-	return ds.API.GetTimeseriesDatabases(req.Context(), req.URL.RawQuery)
+	return ds.API.GetTimeseriesDatabasesCached(req.Context(), req.URL.RawQuery)
 }
 
 func (ds *HistorianDataSource) handleGetAssets(_ http.ResponseWriter, req *http.Request) (interface{}, error) {
-	return ds.API.GetAssets(req.Context(), req.URL.RawQuery)
+	return ds.API.GetAssetsCached(req.Context(), req.URL.RawQuery)
 }
 
 func (ds *HistorianDataSource) handleGetAssetProperties(_ http.ResponseWriter, req *http.Request) (interface{}, error) {
-	return ds.API.GetAssetProperties(req.Context(), req.URL.RawQuery)
+	return ds.API.GetAssetPropertiesCached(req.Context(), req.URL.RawQuery)
 }
 
 func (ds *HistorianDataSource) handleGetEventTypes(_ http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/pkg/datasource/settings.go
+++ b/pkg/datasource/settings.go
@@ -3,18 +3,32 @@ package datasource
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
+// defaultResolutionCacheTTL is how long resolved metadata is reused when the
+// datasource does not set resolutionCacheTTL. At a 2 second dashboard refresh it
+// removes about 97% of the resolution requests; a longer TTL wins little and
+// only widens the window in which a reconfigured asset stays unnoticed.
+const defaultResolutionCacheTTL = "60"
+
 // Settings - data loaded from grafana settings database
 type Settings struct {
-	URL                string `json:"url,omitempty"`
-	Token              string `json:"-,omitempty"`
-	Organization       string `json:"organization,omitempty"`
-	Timeout            string `json:"timeout,omitempty"`
-	QueryTimeout       string `json:"queryTimeout,omitempty"`
+	URL          string `json:"url,omitempty"`
+	Token        string `json:"-,omitempty"`
+	Organization string `json:"organization,omitempty"`
+	Timeout      string `json:"timeout,omitempty"`
+	QueryTimeout string `json:"queryTimeout,omitempty"`
+	// ResolutionCacheTTL is the number of seconds a resolved asset or
+	// measurement lookup is reused, as a string of seconds like the timeouts.
+	// "0" disables the caches. It also bounds how long a dashboard can keep
+	// showing a measurement from a since-reconfigured asset.
+	ResolutionCacheTTL string `json:"resolutionCacheTTL,omitempty"`
 	InsecureSkipVerify bool   `json:"tlsSkipVerify,omitempty"`
 }
 
@@ -45,6 +59,13 @@ func LoadSettings(config backend.DataSourceInstanceSettings) (settings Settings,
 	}
 	if strings.TrimSpace(settings.QueryTimeout) == "" {
 		settings.QueryTimeout = "60"
+	}
+	// A value that does not parse as a non-negative number of seconds, or that
+	// would overflow time.Duration, falls back to the default, so a typo cannot
+	// silently disable the cache.
+	settings.ResolutionCacheTTL = strings.TrimSpace(settings.ResolutionCacheTTL)
+	if seconds, err := strconv.Atoi(settings.ResolutionCacheTTL); err != nil || seconds < 0 || int64(seconds) > math.MaxInt64/int64(time.Second) {
+		settings.ResolutionCacheTTL = defaultResolutionCacheTTL
 	}
 	settings.Token = config.DecryptedSecureJSONData["token"]
 	return settings, settings.isValid()

--- a/pkg/datasource/settings.go
+++ b/pkg/datasource/settings.go
@@ -20,7 +20,7 @@ const defaultResolutionCacheTTL = "60"
 // Settings - data loaded from grafana settings database
 type Settings struct {
 	URL          string `json:"url,omitempty"`
-	Token        string `json:"-,omitempty"`
+	Token        string `json:"-"`
 	Organization string `json:"organization,omitempty"`
 	Timeout      string `json:"timeout,omitempty"`
 	QueryTimeout string `json:"queryTimeout,omitempty"`

--- a/pkg/datasource/settings_test.go
+++ b/pkg/datasource/settings_test.go
@@ -1,0 +1,43 @@
+package datasource
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A malformed resolutionCacheTTL must fall back to the default instead of
+// silently disabling the cache. Only an explicit "0" turns it off.
+func TestLoadSettingsResolutionCacheTTL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ttl  string
+		want string
+	}{
+		{name: "absent uses the default", ttl: "", want: defaultResolutionCacheTTL},
+		{name: "blank uses the default", ttl: `,"resolutionCacheTTL":"  "`, want: defaultResolutionCacheTTL},
+		{name: "a typo uses the default", ttl: `,"resolutionCacheTTL":"60s"`, want: defaultResolutionCacheTTL},
+		{name: "a negative value uses the default", ttl: `,"resolutionCacheTTL":"-5"`, want: defaultResolutionCacheTTL},
+		{name: "a value overflowing time.Duration uses the default", ttl: `,"resolutionCacheTTL":"9223372037"`, want: defaultResolutionCacheTTL},
+		{name: "zero disables", ttl: `,"resolutionCacheTTL":"0"`, want: "0"},
+		{name: "surrounding whitespace is trimmed", ttl: `,"resolutionCacheTTL":" 30 "`, want: "30"},
+		{name: "a valid value is kept", ttl: `,"resolutionCacheTTL":"120"`, want: "120"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			settings, err := LoadSettings(backend.DataSourceInstanceSettings{
+				JSONData:                []byte(`{"url":"http://historian:8000","organization":"org"` + tt.ttl + `}`),
+				DecryptedSecureJSONData: map[string]string{"token": "tok"},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, settings.ResolutionCacheTTL)
+		})
+	}
+}

--- a/pkg/datasource/testhelpers_test.go
+++ b/pkg/datasource/testhelpers_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,29 +75,66 @@ func writeArrowResponse(t *testing.T, w http.ResponseWriter, frames data.Frames)
 	require.NoError(t, err)
 }
 
+// requestRecorder collects the raw query string of every request a fixture
+// serves, keyed by request path. Tests use it to assert how often the
+// datasource reached the historian and with which query.
+type requestRecorder struct {
+	mu      sync.Mutex
+	queries map[string][]string
+}
+
+func (r *requestRecorder) record(path string, rawQuery string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.queries == nil {
+		r.queries = map[string][]string{}
+	}
+	r.queries[path] = append(r.queries[path], rawQuery)
+}
+
+// queriesFor returns the raw query strings seen on path, in arrival order.
+func (r *requestRecorder) queriesFor(path string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.queries[path])
+}
+
 // assetQueryFixture wires up a fake historian with one asset and the given
 // asset properties. The timeseries endpoint returns one frame per requested
 // measurement UUID.
 func assetQueryFixture(t *testing.T, assetUUID uuid.UUID, properties []schemas.AssetProperty) *HistorianDataSource {
 	t.Helper()
+	ds, _ := multiAssetQueryFixture(t, []schemas.Asset{{
+		BaseModel: schemas.BaseModel{UUID: assetUUID, Name: "plant"},
+		AssetPath: "plant",
+	}}, properties)
+	return ds
+}
+
+// multiAssetQueryFixture wires up a fake historian that serves the given assets
+// and asset properties, and records every request it receives. The timeseries
+// endpoint returns one frame per requested measurement UUID.
+func multiAssetQueryFixture(t *testing.T, assets []schemas.Asset, properties []schemas.AssetProperty) (*HistorianDataSource, *requestRecorder) {
+	t.Helper()
+	recorder := &requestRecorder{}
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/assets", func(w http.ResponseWriter, _ *http.Request) {
-		writeJSON(w, []schemas.Asset{{
-			BaseModel: schemas.BaseModel{UUID: assetUUID, Name: "plant"},
-			AssetPath: "plant",
-		}})
+	mux.HandleFunc("GET /api/assets", func(w http.ResponseWriter, r *http.Request) {
+		recorder.record(r.URL.Path, r.URL.RawQuery)
+		writeJSON(w, assets)
 	})
-	mux.HandleFunc("GET /api/asset-properties", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("GET /api/asset-properties", func(w http.ResponseWriter, r *http.Request) {
+		recorder.record(r.URL.Path, r.URL.RawQuery)
 		writeJSON(w, properties)
 	})
 	mux.HandleFunc("POST /api/timeseries/query", func(w http.ResponseWriter, r *http.Request) {
 		query := schemas.Query{}
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&query))
+		recorder.record(r.URL.Path, r.URL.RawQuery)
 		frames := data.Frames{}
 		for _, measurementUUID := range query.MeasurementUUIDs {
 			frames = append(frames, measurementFrame(measurementUUID, 2))
 		}
 		writeArrowResponse(t, w, frames)
 	})
-	return newFakeHistorianDataSource(t, mux)
+	return newFakeHistorianDataSource(t, mux), recorder
 }

--- a/pkg/datasource/testhelpers_test.go
+++ b/pkg/datasource/testhelpers_test.go
@@ -45,13 +45,26 @@ func measurementFrame(measurementUUID string, rows int) *data.Frame {
 }
 
 // newFakeHistorianDataSource spins up a fake historian HTTP server and returns
-// a HistorianDataSource whose API client points at it.
+// a HistorianDataSource whose API client points at it. The resolution caches are
+// disabled, so every lookup reaches the fake historian.
 func newFakeHistorianDataSource(t *testing.T, mux *http.ServeMux) *HistorianDataSource {
+	t.Helper()
+	return newFakeHistorianDataSourceWithTTL(t, mux, 0)
+}
+
+// newFakeHistorianDataSourceWithTTL is newFakeHistorianDataSource with the
+// resolution caches enabled for the given TTL.
+func newFakeHistorianDataSourceWithTTL(t *testing.T, mux *http.ServeMux, resolutionCacheTTL time.Duration) *HistorianDataSource {
 	t.Helper()
 	server := httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 
-	historianAPI, err := api.NewAPIWithToken(server.URL, "token", "org")
+	historianAPI, err := api.NewAPIWithOptions(api.Options{
+		URL:                server.URL,
+		Token:              "token",
+		Organization:       "org",
+		ResolutionCacheTTL: resolutionCacheTTL,
+	})
 	require.NoError(t, err)
 
 	return &HistorianDataSource{
@@ -107,14 +120,14 @@ func assetQueryFixture(t *testing.T, assetUUID uuid.UUID, properties []schemas.A
 	ds, _ := multiAssetQueryFixture(t, []schemas.Asset{{
 		BaseModel: schemas.BaseModel{UUID: assetUUID, Name: "plant"},
 		AssetPath: "plant",
-	}}, properties)
+	}}, properties, 0)
 	return ds
 }
 
 // multiAssetQueryFixture wires up a fake historian that serves the given assets
 // and asset properties, and records every request it receives. The timeseries
 // endpoint returns one frame per requested measurement UUID.
-func multiAssetQueryFixture(t *testing.T, assets []schemas.Asset, properties []schemas.AssetProperty) (*HistorianDataSource, *requestRecorder) {
+func multiAssetQueryFixture(t *testing.T, assets []schemas.Asset, properties []schemas.AssetProperty, resolutionCacheTTL time.Duration) (*HistorianDataSource, *requestRecorder) {
 	t.Helper()
 	recorder := &requestRecorder{}
 	mux := http.NewServeMux()
@@ -136,5 +149,5 @@ func multiAssetQueryFixture(t *testing.T, assets []schemas.Asset, properties []s
 		}
 		writeArrowResponse(t, w, frames)
 	})
-	return newFakeHistorianDataSource(t, mux), recorder
+	return newFakeHistorianDataSourceWithTTL(t, mux, resolutionCacheTTL), recorder
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,8 +1,13 @@
 package util
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"maps"
+	"net/url"
 	"reflect"
+	"slices"
 
 	"github.com/google/uuid"
 )
@@ -32,6 +37,29 @@ func Dedupe[T comparable](arr []T) []T {
 		out = append(out, v)
 	}
 	return out
+}
+
+// AddSortedIndexedParams adds values to query as name[0], name[1], ... in
+// sorted order. url.Values.Encode sorts by key name only, so a caller whose
+// encoded query doubles as a cache key needs the values themselves in a
+// stable order. The input slice is not modified.
+func AddSortedIndexedParams(query url.Values, name string, values []string) {
+	for i, value := range slices.Sorted(slices.Values(values)) {
+		query.Add(fmt.Sprintf("%s[%d]", name, i), value)
+	}
+}
+
+// AddSortedIndexedUUIDs adds the keys of uuids to query as name[0], name[1],
+// ... in sorted order. Sorting the raw bytes gives the same order as sorting
+// the lowercase-hex string form, so the encoding matches
+// AddSortedIndexedParams over the same UUIDs as strings.
+func AddSortedIndexedUUIDs[T any](query url.Values, name string, uuids map[uuid.UUID]T) {
+	sorted := slices.SortedFunc(maps.Keys(uuids), func(a, b uuid.UUID) int {
+		return bytes.Compare(a[:], b[:])
+	})
+	for i, id := range sorted {
+		query.Add(fmt.Sprintf("%s[%d]", name, i), id.String())
+	}
 }
 
 // DropEmpty returns a copy of arr without its empty strings. A dashboard variable
@@ -124,4 +152,3 @@ func MarshalStructToMap(input interface{}) map[string]interface{} {
 
 	return result
 }
-

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2,6 +2,7 @@ package util_test
 
 import (
 	"encoding/json"
+	"net/url"
 	"testing"
 
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/util"
@@ -272,4 +273,38 @@ func TestDeepCopyRoundTripsThroughJSON(t *testing.T) {
 	dstJSON, err := json.Marshal(dst)
 	require.NoError(t, err)
 	assert.JSONEq(t, string(srcJSON), string(dstJSON))
+}
+
+// url.Values.Encode sorts by key name only, so the values of an indexed
+// parameter have to go in sorted for the encoded query to be stable.
+func TestAddSortedIndexedParams(t *testing.T) {
+	t.Parallel()
+
+	first := url.Values{}
+	util.AddSortedIndexedParams(first, "AssetUUIDs", []string{"b", "a", "c"})
+	second := url.Values{}
+	util.AddSortedIndexedParams(second, "AssetUUIDs", []string{"c", "b", "a"})
+
+	assert.Equal(t, first.Encode(), second.Encode(), "permutations of one set must encode identically")
+	assert.Equal(t, "AssetUUIDs%5B0%5D=a&AssetUUIDs%5B1%5D=b&AssetUUIDs%5B2%5D=c", first.Encode())
+
+	input := []string{"b", "a"}
+	util.AddSortedIndexedParams(url.Values{}, "UUIDs", input)
+	assert.Equal(t, []string{"b", "a"}, input, "the input slice must not be modified")
+}
+
+func TestAddSortedIndexedUUIDs(t *testing.T) {
+	t.Parallel()
+
+	uuids := map[uuid.UUID]struct{}{
+		uuid.MustParse("cccccccc-0000-0000-0000-000000000000"): {},
+		uuid.MustParse("aaaaaaaa-0000-0000-0000-000000000000"): {},
+		uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000000"): {},
+	}
+	query := url.Values{}
+	util.AddSortedIndexedUUIDs(query, "AssetUUIDs", uuids)
+
+	assert.Equal(t, "aaaaaaaa-0000-0000-0000-000000000000", query.Get("AssetUUIDs[0]"))
+	assert.Equal(t, "bbbbbbbb-0000-0000-0000-000000000000", query.Get("AssetUUIDs[1]"))
+	assert.Equal(t, "cccccccc-0000-0000-0000-000000000000", query.Get("AssetUUIDs[2]"))
 }


### PR DESCRIPTION
Implements [PBI 37307](https://dev.azure.com/factry/Historian/_workitems/edit/37307): cache asset-property resolution in the Grafana datasource.

An `AssetMeasurementQuery` resolved its assets and properties against Historian on every panel of every dashboard refresh, even though the resolution only changes when an asset is reconfigured. `GetAssetProperties` was measured at 15.6% of Historian CPU on the query path.

## What changed

**Resolution cache** (`pkg/api/cache.go`). A per-client TTL cache with `singleflight` in front of the asset, asset-property and timeseries-database list endpoints. Callers opt in through `GetAssetsCached`, `GetAssetPropertiesCached` and `GetTimeseriesDatabasesCached`; the plain methods stay uncached, and `CheckHealth` keeps using one so a connection test still reaches Historian.

**Cache key determinism**, as a prerequisite. `GetFilteredAssets` and `handleAssetMeasurementQuery` both encoded UUIDs in map iteration order, so the same asset set produced a different query string on nearly every call. Without sorting, the cache would have looked implemented and done nothing.

**Path batching** (`pkg/api/util.go`). `GetFilteredAssets` issued one request per asset path, and Historian serves each `Path` filter from a view that rebuilds the whole asset-path tree, so N paths meant N tree rebuilds. The literal paths now go out as one anchored regex alternation, escaped with `regexp.QuoteMeta` and batched by encoded size: each `Path` filter stays within 4096 percent-encoded bytes, so the request URL cannot outgrow a proxy limit however deep the paths are. A user-supplied regex keeps its own request: its content must not be escaped and it stays unanchored. No version gate needed, Historian has read `Path` as a regex since v6.4.0.

## Policy

TTL, from the new `resolutionCacheTTL` jsonData setting. Default 60 seconds, `"0"` disables. Provisioning-only, like the existing `timeout` and `queryTimeout`, so no UI field.

The TTL is the staleness bound: a reconfigured asset is picked up within it. 60s because the win saturates. At a 2s refresh the hit ratio is `1 - 2/TTL`, so 30s removes 93% of resolution requests, 60s removes 97%, 300s removes 99.3%. Beyond 60s you buy staleness for nothing.

## Deviation from the ticket

AC 2 asked for cross-request bulk batching. Grafana sends one QueryData request per panel, not per dashboard, so that would need a debounce window collecting asset sets from concurrently arriving requests, adding latency to cold loads. `singleflight` gets the same result for the case that matters: concurrent panels resolving the same asset set share one round trip. A cold dashboard whose panels each address a different asset set still issues one call per panel, exactly as today. Discussed on the ticket.

## Notes for the reviewer

- The shared fetch runs on `context.WithoutCancel`, so a panel that navigates away cannot fail the callers waiting on its request. The HTTP client timeout still bounds it. A waiter whose own context is cancelled returns immediately with that error (`DoChan` + select) instead of blocking until the shared fetch finishes.
- `NewAPIWithToken` leaves the caches disabled, which keeps the existing tests counting real requests.
- The cache lives on `api.API`, built per datasource instance, so its contents are already scoped to that instance's token and organization. There is no per-user identity to key on.
- **Worth one manual check before release:** the path escaping is verified against Go's RE2 in the test fake, not against Postgres. `regexp.QuoteMeta` output is ARE-compatible because Postgres reads `\` before any non-alphanumeric as that literal, but a single query against a live Historian with an asset path containing a backslash and a metacharacter would confirm it.
- Found but deliberately not fixed here: [Bug 37509](https://dev.azure.com/factry/Historian/_workitems/edit/37509), a series-limited asset query returns a random subset of series.

## Verification

`go build`, `go vet`, full suite green under `-race` and `-cover`. Coverage up, not down: `pkg/api` 28.7% → 37.3%, `pkg/datasource` 59.2% → 59.6%. `golangci-lint` reports the same 32 issues as `main` does with the same binary, none added.

Both concurrency tests hold the fetch open for the duration and assert with `assert.Never` that it was entered more than once, so a caller that fails to join must be counted while a slow scheduler can only delay one. They can produce a false pass, never a false failure.

