### PR TITLE
Encode UUIDs as strings

### DIFF
--- a/pkg/api/historian.go
+++ b/pkg/api/historian.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/util"
-	"github.com/go-playground/form"
 	"github.com/google/uuid"
 )
 
@@ -328,8 +327,7 @@ func (api *API) GetDistinctEventPropertyValues(ctx context.Context, eventTypePro
 		StopTime:       &request.To,
 		PropertyFilter: request.PropertyFilter,
 	}
-	encoder := form.NewEncoder()
-	urlValues, err := encoder.Encode(filter)
+	urlValues, err := newFormEncoder().Encode(filter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -13,6 +13,7 @@ import (
 	arrow_pb "github.com/factrylabs/factry-historian-datasource.git/pkg/proto"
 	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
 	"github.com/go-playground/form"
+	"github.com/google/uuid"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"google.golang.org/protobuf/proto"
 )
@@ -184,10 +185,19 @@ func fixPropertyFilterValues(filter schemas.EventFilter) schemas.EventFilter {
 	return filter
 }
 
-func getEventFilter(filter schemas.EventFilter) (url.Values, error) {
+// newFormEncoder returns the encoder used for all query parameters sent to Historian. It handles UUIDs explicitly as
+// strings, so they're not sent as byte arrays to the Historian backend.
+func newFormEncoder() *form.Encoder {
 	encoder := form.NewEncoder()
+	encoder.RegisterCustomTypeFunc(func(x interface{}) ([]string, error) {
+		return []string{x.(uuid.UUID).String()}, nil
+	}, uuid.UUID{})
+	return encoder
+}
+
+func getEventFilter(filter schemas.EventFilter) (url.Values, error) {
 	filter = fixPropertyFilterValues(filter)
-	values, err := encoder.Encode(&filter)
+	values, err := newFormEncoder().Encode(&filter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -1,0 +1,94 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/api"
+	"github.com/factrylabs/factry-historian-datasource.git/pkg/schemas"
+	"github.com/google/uuid"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testAssetUUID     = uuid.MustParse("fbbc1516-50a2-4e16-92c0-ea4b38c2997f")
+	testEventTypeUUID = uuid.MustParse("11c36104-92b5-11ef-96de-0242c0a81002")
+)
+
+// assertNoOctetIndexedKeys fails on the shape a form encoder without a uuid.UUID
+// custom type func produces: it walks the underlying [16]byte and emits one key per
+// octet (AssetUUIDs[0][0]=251&AssetUUIDs[0][1]=188&...). Historian 8.2 binds query
+// parameters from the OpenAPI spec and only reads the exact AssetUUIDs key, so the
+// octet keys are silently dropped and the request degenerates to an unfiltered query.
+func assertNoOctetIndexedKeys(t *testing.T, query url.Values) {
+	t.Helper()
+	for key := range query {
+		assert.NotContains(t, key, "][", "UUIDs must be sent as strings, not one octet per key")
+	}
+}
+
+func TestEventQueryEncodesUUIDFiltersAsStrings(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := api.NewAPIWithToken(srv.URL, "tok", "org")
+	require.NoError(t, err)
+
+	_, err = client.EventQuery(context.Background(), schemas.EventFilter{
+		AssetUUIDs:     []uuid.UUID{testAssetUUID},
+		EventTypeUUIDs: []uuid.UUID{testEventTypeUUID},
+	})
+	require.NoError(t, err)
+
+	assertNoOctetIndexedKeys(t, gotQuery)
+	assert.Equal(t, testAssetUUID.String(), gotQuery.Get("AssetUUIDs[0]"))
+	assert.Equal(t, testEventTypeUUID.String(), gotQuery.Get("EventTypeUUIDs[0]"))
+}
+
+func TestGetDistinctEventPropertyValuesEncodesUUIDFiltersAsStrings(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/assets"):
+			_, _ = fmt.Fprintf(w, `[{"UUID":%q,"Name":"Line 1","AssetPath":"Line 1"}]`, testAssetUUID)
+		case strings.HasPrefix(r.URL.Path, "/api/event-types"):
+			_, _ = fmt.Fprintf(w, `[{"UUID":%q,"Name":"Batch"}]`, testEventTypeUUID)
+		default:
+			gotQuery = r.URL.Query()
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := api.NewAPIWithToken(srv.URL, "tok", "org")
+	require.NoError(t, err)
+
+	_, err = client.GetDistinctEventPropertyValues(context.Background(), uuid.NewString(), schemas.EventPropertyValuesRequest{
+		EventQuery: schemas.EventQuery{
+			Assets:     []string{testAssetUUID.String()},
+			EventTypes: []string{testEventTypeUUID.String()},
+		},
+		HistorianInfo: schemas.HistorianInfo{Version: "v8.2.0"},
+		TimeRange:     backend.TimeRange{},
+	})
+	require.NoError(t, err)
+
+	assertNoOctetIndexedKeys(t, gotQuery)
+	assert.Equal(t, testAssetUUID.String(), gotQuery.Get("AssetUUIDs[0]"))
+	assert.Equal(t, testEventTypeUUID.String(), gotQuery.Get("EventTypeUUIDs[0]"))
+}


### PR DESCRIPTION
UUIDs were encoded as byte arrays, causing them to be silently dropped by Historian's OpenAPI validation layer.