### PR TITLE
chore: prepare the v4.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,9 @@ released: 31/08/2026
 
 ### ⚠️ Breaking changes
 
-- Raised the minimum supported Factry Historian version to **v7.3.0**. The plugin no longer carries fallbacks for older Historian APIs:
-  - The pre-v6.4.0 asset and event-type filtering paths (full fetch + in-memory match) have been removed.
-  - The pre-v6.3.0 asset-property filtering fallback has been removed.
-  - All v7.0.0 / v7.1.0 / v7.2.0 / v7.3.0 frontend feature gates have been removed. The corresponding features (datatype filters, value filters, regex/`IN`/`IS NULL`/duration event property filters, periodic-with-dimension property types, time-weighted average aggregation, event property values variable query, asset property keyword/datatype variable filters) are now always available.
+- Factry Historian v7.3.0 is now the minimum supported version. Upgrade your Historian before updating the plugin.
+- All filtering of assets, event types and asset properties is done by Historian. The plugin no longer falls back to fetching everything and filtering it itself, which only older Historian versions needed.
+- Features that were hidden on older Historian versions are now always available: datatype filters, value filters, the regex, `IN`, `IS NULL` and duration event property filters, periodic-with-dimension property types, the time-weighted average aggregation, the event property values variable query and the asset property keyword and datatype variable filters.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,28 @@
 # Changelog
 
 > ⚠️ **Minimum supported Factry Historian version: v7.3.0.**
-> Versions of this plugin from the next release onwards no longer ship compatibility code for Historian instances older than v7.3.0. Earlier Historian versions are not supported — upgrade your Historian before updating this plugin.
+> Versions of this plugin from v4.0.0 onwards no longer ship compatibility code for Historian instances older than v7.3.0. Earlier Historian versions are not supported, so upgrade your Historian before updating this plugin.
 
-## Unreleased
+## v4.0.0
+
+released: 31/08/2026
 
 ### ⚠️ Breaking changes
 
 - Raised the minimum supported Factry Historian version to **v7.3.0**. The plugin no longer carries fallbacks for older Historian APIs:
   - The pre-v6.4.0 asset and event-type filtering paths (full fetch + in-memory match) have been removed.
   - The pre-v6.3.0 asset-property filtering fallback has been removed.
-  - All v7.0.0 / v7.1.0 / v7.2.0 / v7.3.0 frontend feature gates have been removed — the corresponding features (datatype filters, value filters, regex/`IN`/`IS NULL`/duration event property filters, periodic-with-dimension property types, time-weighted average aggregation, event property values variable query, asset property keyword/datatype variable filters) are now always available.
+  - All v7.0.0 / v7.1.0 / v7.2.0 / v7.3.0 frontend feature gates have been removed. The corresponding features (datatype filters, value filters, regex/`IN`/`IS NULL`/duration event property filters, periodic-with-dimension property types, time-weighted average aggregation, event property values variable query, asset property keyword/datatype variable filters) are now always available.
+
+### Bug fixes
+
+- Fixed UUID query parameters being encoded as byte arrays, which Historian's request validation silently dropped. Asset, event type and event configuration filters had no effect on event queries and on the event property values variable query.
+
+### Misc
+
+- Property lookups are skipped when the asset or event type filter matched nothing, instead of asking Historian for every property.
+- Overrode `js-cookie` to 3.0.8, which resolves CVE-2026-46625 reported against the version `@grafana/data` pulls in.
+- Expanded the end-to-end test suite to cover every editor, and added coverage reporting.
 
 ## v3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,7 @@ released: 31/08/2026
 
 ### Bug fixes
 
-- Fixed UUID query parameters being encoded as byte arrays, which Historian's request validation silently dropped. Asset, event type and event configuration filters had no effect on event queries and on the event property values variable query.
-
-### Misc
-
-- Property lookups are skipped when the asset or event type filter matched nothing, instead of asking Historian for every property.
-- Overrode `js-cookie` to 3.0.8, which resolves CVE-2026-46625 reported against the version `@grafana/data` pulls in.
-- Expanded the end-to-end test suite to cover every editor, and added coverage reporting.
+- Fixed asset, event type and event configuration filters not being applied to event queries and to the event property values variable query.
 
 ## v3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ released: 31/08/2026
 
 ### Bug fixes
 
-- Fixed asset, event type and event configuration filters not being applied to event queries and to the event property values variable query.
+- Fixed asset, event type and event configuration filters not being applied to event queries and to the event property values variable query on Historian v8.2 and later.
 
 ## v3.3.0
 


### PR DESCRIPTION
## Summary

Names the `Unreleased` changelog section `v4.0.0` (the Makefile and `package.json` are already at 4.0.0) and fills in the entries for the user-facing commits landed since v3.3.0:

- **Bug fixes:** UUID query parameters were encoded as byte arrays and silently dropped by Historian's request validation, so asset, event type and event configuration filters had no effect on event queries and on the event property values variable query (b6ae55f).
- **Misc:** property lookups are skipped when the asset or event type filter matched nothing (e46ba17), `js-cookie` overridden to 3.0.8 for CVE-2026-46625 (ff5b178), e2e suite expanded across every editor with coverage reporting (f111f72).

Left out as not user-facing: CI runtime and cache changes, the `templateVariables` prop type fix, the `rangeValCopy` fix, test-only commits and the version bumps.

Also in this change:

- The compatibility banner at the top now names v4.0.0 instead of "the next release".
- The two em dashes in the top section are gone, matching house style.

## Work item

[PBI 37526: release grafana datasource v4.0.0](https://dev.azure.com/factry/Historian/_workitems/edit/37526)

## Testing

Docs only, no code change. Worth checking that the section shape still matches what the `archbee-sync` job expects: a `## v4.0.0` heading, a `released: DD/MM/YYYY` line, then `###` subsections. The `released:` date is set to 31/08/2026; if the tag is pushed on another day, update it (the job only fills the date in when it is missing).