### PR TITLE
fix(coverage): stop reading GOCOVERDIR from the plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Build coverage-instrumented backend
         if: needs.build.outputs.has-backend == 'true'
         run: |
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -cover -covermode=atomic -coverpkg=./pkg/... -o dist/gpx_factry-historian-datasource_linux_amd64 ./pkg
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -cover -covermode=atomic -coverpkg=./pkg/... -tags e2ecover -o dist/gpx_factry-historian-datasource_linux_amd64 ./pkg
           rm -f dist/MANIFEST.txt
 
       - name: Execute permissions on binary

--- a/docker-compose.e2e.yaml
+++ b/docker-compose.e2e.yaml
@@ -19,11 +19,14 @@ services:
       # /etc/grafana/provisioning is ignored (docker-compose appends volume
       # lists, so we cannot replace the dev mount in place).
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning-e2e
-      # Backend e2e coverage: the plugin binary flushes Go coverage counters to
-      # GOCOVERDIR when built with `go build -cover` (see pkg/coverageflush.go).
-      # forward_host_env_vars takes PLUGIN IDs: Grafana >= 12.4 no longer
-      # passes host env vars to plugin subprocesses unless the plugin is
-      # listed. Both are no-ops for a regular (non -cover) binary.
+      # Backend e2e coverage: a binary built with
+      # `go build -cover -tags e2ecover` flushes Go coverage counters to the
+      # /coverage mount below (see pkg/coverageflush.go, which hardcodes that
+      # path because plugins may not read environment variables). GOCOVERDIR
+      # covers the runtime's own write-at-exit; forward_host_env_vars takes
+      # PLUGIN IDs, since Grafana >= 12.4 no longer passes host env vars to
+      # plugin subprocesses unless the plugin is listed. Both are no-ops for a
+      # regular (non -cover) binary.
       GOCOVERDIR: /coverage
       GF_PLUGINS_FORWARD_HOST_ENV_VARS: factry-historian-datasource
       # Grafana >= 11.5 preinstalls a few first-party apps (explore traces,

--- a/pkg/coverageflush.go
+++ b/pkg/coverageflush.go
@@ -1,28 +1,31 @@
+//go:build e2ecover
+
 package main
 
 import (
-	"os"
 	"runtime/coverage"
 	"time"
 )
 
-// startCoverageFlusher periodically writes coverage counter data to
-// GOCOVERDIR. It is a no-op unless the binary was built with `go build
-// -cover` AND GOCOVERDIR is set (the e2e suite does both; production builds
-// never set GOCOVERDIR). The periodic flush is needed because Grafana kills
+// coverDir is where the e2e stack mounts the coverage output directory
+// (docker-compose.e2e.yaml). It is a constant rather than an environment
+// lookup: Grafana's plugin validator forbids plugins from reading
+// environment variables.
+const coverDir = "/coverage"
+
+// startCoverageFlusher periodically writes coverage counter data to coverDir.
+// It is only compiled into the binary the e2e suite builds
+// (`go build -cover -tags e2ecover`); released builds get the no-op in
+// coverageflush_noop.go. The periodic flush is needed because Grafana kills
 // the plugin subprocess on shutdown, so the usual write-at-exit never runs.
 func startCoverageFlusher() {
-	dir := os.Getenv("GOCOVERDIR")
-	if dir == "" {
-		return
-	}
-
 	go func() {
 		// WriteMetaDir/WriteCountersDir return an error when the binary is not
-		// built with -cover; ignoring it keeps this dormant in normal builds.
-		_ = coverage.WriteMetaDir(dir)
+		// built with -cover or the directory is missing; ignoring it keeps this
+		// harmless outside the e2e stack.
+		_ = coverage.WriteMetaDir(coverDir)
 		for range time.Tick(15 * time.Second) {
-			_ = coverage.WriteCountersDir(dir)
+			_ = coverage.WriteCountersDir(coverDir)
 		}
 	}()
 }

--- a/pkg/coverageflush_noop.go
+++ b/pkg/coverageflush_noop.go
@@ -1,0 +1,7 @@
+//go:build !e2ecover
+
+package main
+
+// startCoverageFlusher does nothing in a released build. The coverage
+// flusher lives in coverageflush.go behind the e2ecover build tag.
+func startCoverageFlusher() {}

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,15 +48,17 @@ of the plugin:
 - **Backend**: build the plugin binary with coverage instrumentation first:
 
   ```sh
-  go build -cover -covermode=atomic -coverpkg=./pkg/... \
+  go build -cover -covermode=atomic -coverpkg=./pkg/... -tags e2ecover \
     -o dist/gpx_factry-historian-datasource_linux_amd64 ./pkg
   mkdir -p coverage/e2e-backend-raw && chmod 777 coverage/e2e-backend-raw
   ```
 
-  `docker-compose.e2e.yaml` sets `GOCOVERDIR` and forwards it to the plugin
-  subprocess; `pkg/coverageflush.go` flushes counters every 15s (Grafana kills
-  the plugin on shutdown, so the usual write-at-exit never runs). Raw counter
-  files land in `coverage/e2e-backend-raw/`.
+  `docker-compose.e2e.yaml` mounts `coverage/e2e-backend-raw` at `/coverage`;
+  `pkg/coverageflush.go`, compiled in only under the `e2ecover` build tag,
+  flushes counters to that path every 15s (Grafana kills the plugin on
+  shutdown, so the usual write-at-exit never runs). The path is hardcoded
+  because Grafana's plugin validator forbids reading environment variables.
+  Raw counter files land in `coverage/e2e-backend-raw/`.
 
 Render the combined report (also used by CI for the job summary):
 


### PR DESCRIPTION
Grafana's plugin review flagged v4.0.0 with `code-rules-access-forbidden-os-environment`: `pkg/coverageflush.go` read `GOCOVERDIR` via `os.Getenv`. Plugins may not read environment variables.

## Change

- `pkg/coverageflush.go` moves behind the `e2ecover` build tag; `pkg/coverageflush_noop.go` provides an empty `startCoverageFlusher()` for every other build, so a released binary contains no flusher.
- The output directory is now a constant (`/coverage`, the mount `docker-compose.e2e.yaml` already provides) instead of an env lookup, so the forbidden construct is gone from the source tree rather than only from the release build. Both halves matter: it is not established that the validator honours build tags when it walks the repository.
- The CI coverage build passes `-tags e2ecover`.
- `GOCOVERDIR` stays in the compose file for the Go runtime's own write-at-exit. No Go code reads it: `grep -rn 'os.Getenv|os.Environ|os.LookupEnv' pkg/ tests/` is empty.

## Testing

- `go vet ./pkg/...` with and without `-tags e2ecover`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build`, plain and `-cover -covermode=atomic -coverpkg=./pkg/... -tags e2ecover`
- `go test ./pkg/...`
- The e2e coverage leg in CI exercises the tagged path end to end.

The validator rule itself could not be reproduced locally: `plugin-validator` skips the code-diff analyzer with `Code diff skipped due to errors in osv-scanner`, before and after this change alike. Those osv findings (grpc, browserslist, fast-uri) are handled separately.