### PR TITLE
chore(dependencies): bump js-yaml to clear CVE-2026-84375

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ overrides:
   dompurify: 3.4.13
   fast-uri: 3.1.7
   js-cookie: 3.0.8
-  js-yaml@3: 3.15.1
-  js-yaml@4: 4.3.1
+  js-yaml@3: 3.15.2
+  js-yaml@4: 4.3.2
   nanoid@3: 3.3.18
   postcss: 8.5.26
   prismjs: 1.30.0
@@ -3137,12 +3137,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.1:
-    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+  js-yaml@3.15.2:
+    resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
     hasBin: true
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdoc-type-pratt-parser@4.1.0:
@@ -5263,7 +5263,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5565,7 +5565,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -8662,12 +8662,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,8 +34,8 @@ overrides:
   dompurify: 3.4.13
   fast-uri: 3.1.7
   js-cookie: 3.0.8
-  'js-yaml@3': 3.15.1
-  'js-yaml@4': 4.3.1
+  'js-yaml@3': 3.15.2
+  'js-yaml@4': 4.3.2
   'nanoid@3': 3.3.18
   postcss: 8.5.26
   prismjs: 1.30.0


### PR DESCRIPTION
Grafana blocked the v4.0.1 submission (ticket 242390). The 10 September report leaves one error:

> ❌ osv-scanner-high-severity-vulnerabilities-detected
> SEVERITY: HIGH in package js-yaml, vulnerable to CVE-2026-84375
> osv-scanner detected 1 unique high severity issues for lockfile: pnpm-lock.yaml

Both pinned js-yaml lines are in range (`>=3.0.0 <3.15.2` and `>=4.0.0 <4.3.2`, "maxTotalMergeKeys does not limit CPU use for empty merge sources"), so both overrides move up: 3.15.1 -> 3.15.2 and 4.3.1 -> 4.3.2. Patch releases, no `go.mod` or source change.

The `govulncheck-scan-failed` error from the 8 September report is gone in the 10 September run without any change on our side. It was Grafana's own toolchain mismatch (`go1.26` source-processing packages against `go1.27` `go list`), so nothing to fix here.

## Testing

- `pnpm audit`: 0 high or critical advisories
- `pnpm run test:ci`: 16 suites, 226 tests
- `make validate` on a freshly built zip exits 0. Only the sponsorship-link recommendation and the expected `unsigned plugin` warning remain.

The same commit is on `fix/js-yaml-cve`, branched from the `v4.0.1` tag, for a v4.0.2 resubmission that carries nothing else.
